### PR TITLE
Load frame script

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -4,12 +4,10 @@
 /* global Feature, Services */ // Cu.import
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(startup|shutdown|install|uninstall)" }]*/
 
-//TODO bdanforth: Fix bootstrap log; submit patch to ssat
-
 const { classes: Cc, interfaces: Ci, utils: Cu } = Components;
-Cu.import("resource://gre/modules/Log.jsm");
-Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "Services",
+  "resource://gre/modules/Services.jsm");
 
 // Create a new instance of the ConsoleAPI so we can control the maxLogLevel with Config.jsm.
 XPCOMUtils.defineLazyGetter(this, "log", () => {
@@ -28,54 +26,30 @@ const STUDYUTILSPATH = `${__SCRIPT_URI_SPEC__}/../${config.studyUtilsPath}`;
 const { studyUtils } = Cu.import(STUDYUTILSPATH, {});
 
 const REASONS = studyUtils.REASONS;
-const UI_AVAILABLE_NOTIFICATION = "sessionstore-windows-restored";
+const UI_AVAILABLE_NOTIFICATION = "browser-delayed-startup-finished";
 
-// QA NOTE: Study Specific Modules - package.json:addon.chromeResource
-const BASE = `button-icon-preference`;
+// Study-specific modules
+const BASE = "tracking-protection-messaging";
 XPCOMUtils.defineLazyModuleGetter(this, "Feature", `resource://${BASE}/lib/Feature.jsm`);
-
-
-/* Example addon-specific module imports.  Remember to Unload during shutdown!
-
-  // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Using
-
-
-   Ideally, put ALL your feature code in a Feature.jsm file,
-   NOT in this bootstrap.js.
-
-  const BASE=`template-shield-study`;
-  XPCOMUtils.defineLazyModuleGetter(this, "SomeExportedSymbol",
-    `resource://${BASE}/SomeModule.jsm");
-
-  XPCOMUtils.defineLazyModuleGetter(this, "Preferences",
-    "resource://gre/modules/Preferences.jsm");
-*/
-
-// Create a new instance of the ConsoleAPI so we can control the maxLogLevel.
-XPCOMUtils.defineLazyGetter(this, "log", () => {
-  const ConsoleAPI = Cu.import("resource://gre/modules/Console.jsm", {}).ConsoleAPI;
-  const consoleOptions = {
-    maxLogLevel: config.log.bootstrap.level,
-    prefix: "TPStudy",
-  };
-  return new ConsoleAPI(consoleOptions);
-});
 
 this.Bootstrap = {
   async startup(addonData, reason) {
+    // TODO bdanforth: Turn off TP always just in case before applying treatments
 
+    // Randomize frame script URL due to bug 1051238. TODO bdanforth add ?${Math.random()}
+    this.FRAME_SCRIPT_URL = `resource://${BASE}/content/new-tab-variation.js`;
     // validate study config
     studyUtils.setup({...config, addon: { id: addonData.id, version: addonData.version }});
     // TODO bdanforth: patch studyUtils to setLoggingLevel as part of setup method
     studyUtils.setLoggingLevel(config.log.studyUtils.level);
 
+    // choose and set variation
+    const variation = await this.selectVariation();
+
     // if addon was just installed, check if user is eligible as specified in Config.jsm
     if ((REASONS[reason]) === "ADDON_INSTALL" && await !this.isEligible(reason)) {
       return;
     }
-
-    // choose and set variation
-    const variation = await this.selectVariation();
 
     /*
     * Adds the study to the active list of telemetry experiments, and sends the "installed"
@@ -96,6 +70,7 @@ this.Bootstrap = {
     if (!Services.wm.getMostRecentWindow("navigator:browser")) {
       Services.obs.addObserver(this, UI_AVAILABLE_NOTIFICATION);
     } else {
+      // TODO bdanforth: check if window is private before adding UI
       this.addFeature(variation, reason);
     }
   },
@@ -109,6 +84,17 @@ this.Bootstrap = {
     log.debug("shutdown", REASONS[reason] || reason);
     // FRAGILE: handle uninstalls initiated by USER or by addon
     if (reason === REASONS.ADDON_UNINSTALL || reason === REASONS.ADDON_DISABLE) {
+      // ensure the frame script is not loaded into any new tabs
+      Services.mm.removeDelayedFrameScript(this.FRAME_SCRIPT_URL);
+      // TODO bdanforth: disable frame scripts already loaded
+      /*
+      * There is no mechanism to unload frame scripts which are already loaded.
+      * You need to send a message to your frame scripts, telling them to disable
+      * themselves; for example, by undoing any changes they've made or removing
+      * any event listeners.
+      * Note: Frame scripts are automatically unloaded on tab close.
+      */
+
       log.debug("uninstall or disable");
       if (!studyUtils._isEnding) {
         // we are the first 'uninstall' requestor => must be user action.
@@ -140,14 +126,12 @@ this.Bootstrap = {
   observe(subject, topic, data) {
     if (topic === UI_AVAILABLE_NOTIFICATION) {
       Services.obs.removeObserver(this, UI_AVAILABLE_NOTIFICATION);
-      this.onBrowserReady();
+      this.addFeature();
     }
   },
 
   addFeature(variation, reason) {
-    // TODO bdanforth: load frame script in Feature.init
-    // Services.mm.loadFrameScript("resource://tracking-protection-study/tracking-study-content.js", true);
-    // Feature.init();
+    Services.mm.loadFrameScript(this.FRAME_SCRIPT_URL, true);
     // Start up your feature, with specific variation info.
     this.feature = new Feature({variation, studyUtils, reasonName: REASONS[reason]});
   },

--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -1,0 +1,51 @@
+// Modified from https://github.com/rhelmer/tracking-protection-study/
+
+/* global addMessageListener sendAsyncMessage*/
+
+"use strict";
+
+const ABOUT_HOME_URL = "about:home";
+const ABOUT_NEWTAB_URL = "about:newtab";
+
+class TrackingProtectionStudy {
+  constructor(contentWindow) {
+    this.init(contentWindow);
+  }
+
+  async init(contentWindow) {
+    addMessageListener("TrackingStudy:Totals", (msg) => {
+      this.handleMessageFromChrome(msg, contentWindow);
+    });
+  }
+
+  handleMessageFromChrome(msg, contentWindow) {
+    const root = contentWindow.document.getElementById("root");
+    let message = contentWindow.document.getElementById("tracking-study-message");
+    if (!message) {
+      message = contentWindow.document.createElement("span");
+      message.id = "tracking-study-message";
+    }
+    let value;
+    switch (msg.data.type) {
+      case "totalBlockedResources":
+        value = msg.data.value;
+        message.innerHTML = `Hello from Tracking Protection Study! Total blocked resources: ${ value }`;
+        root.parentElement.prepend(message);
+        break;
+      default:
+        throw new Error(`Message type not recognized, ${ msg.data.type }`);
+    }
+  }
+}
+
+addEventListener("load", function onLoad(evt) {
+  const window = evt.target.defaultView;
+  const location = window.location.href;
+  if (location === ABOUT_NEWTAB_URL || location === ABOUT_HOME_URL) {
+    // queues a function to be called during a browser's idle periods
+    window.requestIdleCallback(() => {
+      new TrackingProtectionStudy(window);
+      sendAsyncMessage("TrackingStudy:OnContentMessage", {action: "get-totals"});
+    });
+  }
+}, true);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -1,21 +1,22 @@
 "use strict";
 
 
-/**  Example Feature module for a Shield Study.
+/**  What this Feature does: TODO bdanforth: complete
   *
   *  UI:
-  *  - during INSTALL only, show a notification bar with 2 buttons:
-  *    - "Thanks".  Accepts the study (optional)
-  *    - "I don't want this".  Uninstalls the study.
+  *  - during INSTALL only, show an introductory panel with X options
+  *    - ((add options))
+  *  - ((add other UI features))
   *
-  *  Firefox code:
-  *  - Implements the 'introduction' to the 'button choice' study, via notification bar.
+  *  This module:
+  *  - Implements the 'introduction' to the 'tracking protection messaging' study, via panel.
+  *  - ((add other functionality))
   *
-  *  Demonstrates `studyUtils` API:
-  *
+  *  Uses `studyUtils` API for:
   *  - `telemetry` to instrument "shown", "accept", and "leave-study" events.
   *  - `endStudy` to send a custom study ending.
-  *
+  *  - ((add other uses))
+  *  - ((get study ending URL(s) from rrayborn))
   **/
 
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(EXPORTED_SYMBOLS|Feature)" }]*/
@@ -30,19 +31,8 @@ const EXPORTED_SYMBOLS = ["Feature"];
 XPCOMUtils.defineLazyModuleGetter(this, "RecentWindow",
   "resource:///modules/RecentWindow.jsm");
 
-/** Return most recent NON-PRIVATE browser window, so that we can
-  * maniuplate chrome elements on it.
-  */
-function getMostRecentBrowserWindow() {
-  return RecentWindow.getMostRecentBrowserWindow({
-    private: false,
-    allowPopups: false,
-  });
-}
-
-
 class Feature {
-  /** A Demonstration feature.
+  /** The study feature.
     *
     *  - variation: study info about particular client study variation
     *  - studyUtils:  the configured studyUtils singleton.
@@ -50,17 +40,18 @@ class Feature {
     *
     */
   constructor({variation, studyUtils, reasonName}) {
-    // unused.  Some other UI might use the specific variation info for things.
     this.variation = variation;
     this.studyUtils = studyUtils;
+    this.addListeners();
 
     // only during INSTALL
     if (reasonName === "ADDON_INSTALL") {
-      this.introductionNotificationBar();
+      this.showIntroPanel();
     }
   }
 
-  /** Display instrumented 'notification bar' explaining the feature to the user
+  /**
+    *   Display instrumented 'introductory panel' explaining the feature to the user
     *
     *   Telemetry Probes:
     *
@@ -70,62 +61,35 @@ class Feature {
     *
     *   - {event: introduction-leave-study}
     *
-    *    Note:  Bar WILL NOT SHOW if the only window open is a private window.
+    *    Note:  Panel WILL NOT SHOW if the only window open is a private window.
     *
-    *    Note:  Handling of 'x' is not implemented.  For more complete implementation:
-    *
-    *      https://github.com/gregglind/57-perception-shield-study/blob/680124a/addon/lib/Feature.jsm#L148-L152
     *
   */
-  introductionNotificationBar() {
-    const feature = this;
-    const recentWindow = getMostRecentBrowserWindow();
-    const doc = recentWindow.document;
-    const notificationBox = doc.querySelector(
-      "#high-priority-global-notificationbox"
-    );
-
-    if (!notificationBox) return;
-
-    // api: https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Method/appendNotification
-    const notice = notificationBox.appendNotification(
-      "Welcome to the new feature! Look for changes!",
-      "feature orienation",
-      null, // icon
-      notificationBox.PRIORITY_INFO_HIGH, // priority
-      // buttons
-      [{
-        label: "Thanks!",
-        isDefault: true,
-        callback: function acceptButton() {
-          console.log("clicked THANKS!");
-          feature.telemetry({
-            event: "introduction-accept",
-          });
-        },
-      },
-      {
-        label: "I do not want this.",
-        callback: function leaveStudyButton() {
-          console.log("clicked NO!");
-          feature.telemetry({
-            event: "introduction-leave-study",
-          });
-          feature.studyUtils.endStudy("introduction-leave-study");
-        },
-      }],
-      // callback for nb events
-      null
-    );
-
-    // used by testing to confirm the bar is set with the correct config
-    notice.setAttribute("data-study-config", JSON.stringify(this.variation));
-    feature.telemetry({
-      event: "introduction-shown",
-    });
-
+  showIntroPanel() {
+    // TODO bdanforth: show onboarding TP panel here, if window is not private
   }
-  /* good practice to have the literal 'sending' be wrapped up */
+
+  addListeners() {
+    // content listener
+    Services.mm.addMessageListener(
+      "TrackingStudy:OnContentMessage",
+      this.handleMessageFromContent.bind(this)
+    );
+  }
+
+  handleMessageFromContent(msg) {
+    switch (msg.data.action) {
+      case "get-totals":
+        msg.target.messageManager.sendAsyncMessage("TrackingStudy:Totals", {
+          type: "totalBlockedResources",
+          value: 12, // TODO bdanforth: pass actual value here
+        });
+        break;
+      default:
+        throw new Error(`Message type not recognized, ${ msg.data.action }`);
+    }
+  }
+
   telemetry(stringStringMap) {
     this.studyUtils.telemetry(stringStringMap);
   }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "shield-studies-addon-template",
-  "description": "Template Shield Study",
+  "name": "tracking-protection-messaging-shield-study",
+  "description": "Tracking Protection Messaging Shield Study",
   "version": "1.2.0",
-  "author": "Mozilla Gregg Lind <glind@mozilla.com>",
+  "author": "Mozilla Bianca Danforth <bdanforth@mozilla.com>",
   "addon": {
     "$ABOUT": "use these variables fill the moustache templates",
-    "id": "button-icon-preference@shield-study.mozilla.com",
+    "id": "tracking-protection-messaging@shield-study.mozilla.com",
     "name": "Button Icon Preference Study (Shield Study Example)",
     "minVersion": "57.0",
     "maxVersion": "*",
     "multiprocessCompatible": true,
     "hasEmbeddedWebExtension": true,
-    "chromeResource": "button-icon-preference",
-    "creator": "Gregg Lind <glind@mozilla.com>",
-    "description": "template shield study to serve a as base.  This one is about Toolbar Buttons",
+    "chromeResource": "tracking-protection-messaging",
+    "creator": "Bianca Danforth <bdanforth@mozilla.com>",
+    "description": "Tracking Protection Messaging Shield Study",
     "bugzilla": "<tbd: bug to attach for signing>",
     "iconPath": "icon.png"
   },
   "bugs": {
-    "url": "https://github.com/mozilla/shield-studies-addon-template/issues"
+    "url": "https://github.com/biancadanforth/tracking-protection-shield-study/issues"
   },
   "devDependencies": {
     "addons-linter": "^0.28.2",
@@ -46,7 +46,7 @@
     "selenium-webdriver": "^3.5.0",
     "shield-studies-addon-utils": "^4.1.0"
   },
-  "homepage": "http://github.com/mozilla/shield-studies-addon-template",
+  "homepage": "https://github.com/biancadanforth/tracking-protection-shield-study",
   "keywords": [
     "mozilla",
     "legacy-addon",
@@ -54,10 +54,10 @@
     "shield-study"
   ],
   "license": "MIT",
-  "main": "index.js",
+  "main": "bootstrap.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mozilla/shield-studies-addon-template.git"
+    "url": "git://github.com/biancadanforth/tracking-protection-shield-study.git"
   },
   "scripts": {
     "build": "bash ./bin/xpi.sh",

--- a/test/utils.js
+++ b/test/utils.js
@@ -33,6 +33,9 @@ const FIREFOX_PREFERENCES = {
   // NECESSARY for all 57+ builds
   "extensions.legacy.enabled": true,
 
+  // Temporarily installed addons can break due to sandbox, see Bug #1423687
+  "security.sandbox.content.level": 2,
+
   /** WARNING: gecko webdriver sets many additional prefs at:
     * https://dxr.mozilla.org/mozilla-central/source/testing/geckodriver/src/prefs.rs
     *


### PR DESCRIPTION
This PR adds some sample content to all new tab pages. It says "Hello from the Tracking Protection Study! Total blocked resources: 12".

![screen shot 2017-12-18 at 2 34 33 pm](https://user-images.githubusercontent.com/17437436/34131472-9b27c9aa-e400-11e7-9fd1-a7731c54f12d.png)

* Load frame scripts into all windows using the global message manager (See this Bugzilla [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1423687))
  * Required lowering the sandbox level during development/testing, see Bugzilla bug 1423687.
* Set up message passing between frame scripts and JSM scripts
  * Currently, a "span" element is added to new tab pages via the frame script, `new-tab-variation.js` with some sample content from `Feature.jsm`.
* Updated package.json with study-specific information

Next steps:
* Add actual values for blocked resources, time saved, etc.
* Insert content in new tab as a new row in the main content area of the page, shifting other content down.