### PR TITLE
WIP - add timeSaved

### DIFF
--- a/addon/Config.jsm
+++ b/addon/Config.jsm
@@ -96,10 +96,10 @@ var config = {
   "weightedVariations": [
     {"name": "fast",
       "weight": 1.5},
-    {"name": "private",
-      "weight": 1.5},
-    {"name": "adBlocking",
-      "weight": 1},
+    // {"name": "private",
+    //   "weight": 1.5},
+    // {"name": "control",
+    //   "weight": 1},
   ],
 
 

--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -7,7 +7,7 @@
 const ABOUT_HOME_URL = "about:home";
 const ABOUT_NEWTAB_URL = "about:newtab";
 // for calculating time saved per page
-const LOAD_START_TIME = Date.now() / 1000 / 60;
+const LOAD_START_TIME = Date.now();
 
 class TrackingProtectionStudy {
   constructor(contentWindow) {
@@ -40,17 +40,15 @@ class TrackingProtectionStudy {
   }
 
   addContentToNewTab(state, doc) {
-    // TODO bdanforth: Ideally: Update numbers dynamically on page even without refresh?
-    const minutes = state.totalTimeSaved;
+    const minutes = state.totalTimeSaved / 1000 / 60;
     // FIXME commented out for testing
-    // if (minutes >= 1 && this.blockedRequests) {
     // if we haven't blocked anything yet, don't modify the page
-    if (state.totalBlockedResources) {
+    if (true/*state.totalBlockedResources && minutes >= 1*/) {
       let message = state.newTabMessage;
       message = message.replace("${blockedRequests}", state.totalBlockedResources);
       message = message.replace("${blockedCompanies}", state.totalBlockedCompanies);
       message = message.replace("${blockedSites}", state.totalBlockedWebsites);
-      message = message.replace("${minutes}", minutes.toPrecision(3));
+      message = message.replace("${minutes}", minutes.toFixed(2));
 
       // Check if the study UI has already been added to this page
       const tpContent = doc.getElementById("tracking-protection-message");
@@ -89,15 +87,14 @@ class TrackingProtectionStudy {
   }
 
   updateTPNumbers(state, doc) {
-    const minutes = state.totalTimeSaved;
-    console.log(minutes);
+    const minutes = state.totalTimeSaved / 1000 / 60;
     const span = doc.getElementById("tracking-protection-numbers");
     if (span) {
       let message = state.newTabMessage;
       message = message.replace("${blockedRequests}", state.totalBlockedResources);
       message = message.replace("${blockedCompanies}", state.totalBlockedCompanies);
       message = message.replace("${blockedSites}", state.totalBlockedWebsites);
-      message = message.replace("${minutes}", minutes);
+      message = message.replace("${minutes}", minutes.toFixed(2));
       span.innerHTML = message;
     }
   }
@@ -105,10 +102,10 @@ class TrackingProtectionStudy {
 
 // estimate the amount of per page load time saved in minutes
 function getTimeSaved(pageStartTime) {
-  const pageEndTime = Date.now() / 1000 / 60;
+  const pageEndTime = Date.now();
   // TP estimated to save 44% page load time: https://tinyurl.com/l4mnbol
   const timeSaved = 0.44 * (pageEndTime - pageStartTime);
-  return timeSaved.toFixed(4);
+  return timeSaved; // in ms
 }
 
 addEventListener("load", function onLoad(evt) {

--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -89,7 +89,7 @@ class TrackingProtectionStudy {
   }
 
   updateTPNumbers(state, doc) {
-    const minutes = state.timeSaved;
+    const minutes = state.totalTimeSaved;
     console.log(minutes);
     const span = doc.getElementById("tracking-protection-numbers");
     if (span) {
@@ -122,11 +122,15 @@ addEventListener("load", function onLoad(evt) {
       sendAsyncMessage("TrackingStudy:OnContentMessage", {action: "get-totals"});
     });
   } else if (protocol === "http:" || protocol === "https:") {
-    const timeSaved = getTimeSaved(LOAD_START_TIME);
-    sendAsyncMessage("TrackingStudy:OnContentMessage",
-      {
-        action: "update-time-saved",
-        timeSaved,
-      });
+    // only want pages user navigates to directly
+    if (evt.target.referrer === "") {
+      const timeSaved = getTimeSaved(LOAD_START_TIME);
+      sendAsyncMessage("TrackingStudy:OnContentMessage",
+        {
+          action: "update-time-saved",
+          timeSaved,
+        }
+      );
+    }
   }
 }, true);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -444,7 +444,9 @@ class Feature {
   setPageActionCounter(doc, counter) {
     const toolbarButton = doc.getElementById("tracking-protection-study-button");
     if (toolbarButton) {
-      toolbarButton.setAttribute("label", counter);
+      // if "fast" treatment, convert counter from ms to seconds and add unit "s"
+      const label = this.treatment === "private" ? counter : `${Math.round(counter / 1000)}s`;
+      toolbarButton.setAttribute("label", label);
     }
   }
 

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -134,7 +134,7 @@ class Feature {
       // if didn't do this, you might get two tabs loading the same page trying to update the same counter.
       blockedResources: new Map(),
       // TODO bdanforth: reset to 0 after testing
-      totalBlockedResources: 1,
+      totalBlockedResources: 0,
       blockedCompanies: new Set(),
       totalBlockedCompanies: 0,
       blockedWebsites: new Set(),
@@ -554,8 +554,7 @@ class Feature {
         });
         break;
       case "update-time-saved":
-        this.state.totalTimeSaved += Number.parseFloat(msg.data.timeSaved);
-        // TODO bdanforth: minimize number of decimal places after 0.
+        this.state.totalTimeSaved += Number.parseInt(msg.data.timeSaved);
         break;
       default:
         throw new Error(`Message type not recognized, ${ msg.data.action }`);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -76,21 +76,20 @@ class Feature {
   }
 
   async init(treatment) {
-
+    console.log(treatment);
     // TODO bdanforth: get treatment(s) from bootstrap/studyUtils
     // define treatments as STRING: fn(browserWindow, url)
     this.TREATMENTS = {
       fast: this.showIntroPanel.bind(this), // opens a doorhanger on addon install only
       private: this.showIntroPanel.bind(this),
-      adBlocking: this.showIntroPanel.bind(this),
     };
 
     this.treatment = treatment;
     // TODO bdanforth: update newtab messages copy
-    const newtab_messages = [
-      "Firefox blocked ${blockedRequests} trackers today<br/> from ${blockedCompanies} companies that track your browsing",
-      "Firefox blocked ${blockedRequests} trackers today<br/> and saved you ${minutes} minutes",
-    ];
+    const newtab_messages = {
+      fast: "Firefox blocked ${blockedRequests} trackers today<br/> and saved you ${minutes} minutes",
+      private: "Firefox blocked ${blockedRequests} trackers today<br/> from ${blockedCompanies} companies that track your browsing",
+    };
     // TODO bdanforth: update with final URLs
     const learnMore_urls = [
       "http://www.mozilla.com",
@@ -126,8 +125,8 @@ class Feature {
 
     this.state = {
       // TODO bdanforth: choose message based on treatment branch
-      newTabMessage: newtab_messages[0],
-      timeSave: 0,
+      newTabMessage: newtab_messages[this.treatment],
+      totalTimeSaved: 0,
       // a <browser>:counter map for the number of blocked resources for a particular browser
       // Why is this mapped with <browser>?
       // You may have the same site in multiple tabs; should you use the same counter for both?
@@ -553,6 +552,10 @@ class Feature {
           type: "newTabContent",
           state: this.state,
         });
+        break;
+      case "update-time-saved":
+        this.state.totalTimeSaved += Number.parseFloat(msg.data.timeSaved);
+        // TODO bdanforth: minimize number of decimal places after 0.
         break;
       default:
         throw new Error(`Message type not recognized, ${ msg.data.action }`);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "minVersion": "57.0",
     "maxVersion": "*",
     "multiprocessCompatible": true,
-    "hasEmbeddedWebExtension": true,
+    "hasEmbeddedWebExtension": false,
     "chromeResource": "tracking-protection-messaging",
     "creator": "Bianca Danforth <bdanforth@mozilla.com>",
     "description": "Tracking Protection Messaging Shield Study",


### PR DESCRIPTION
This PR updates the new tab page with total time saved per session in minutes and the pageAction badge with the time saved per page in seconds.

![pr14tpstudy](https://user-images.githubusercontent.com/17437436/34845469-c5dd5634-f6c9-11e7-9e08-4fb1b7671002.gif)

Page load times per [Google's PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/?hl=en-US&utm_source=PSI&utm_medium=incoming-link&utm_campaign=PSI) (PSI) and [pingdom](https://tools.pingdom.com/) are usually on the order of 1-10s, so the estimate for page load time in this addon from the `window.performance` API and the resulting `timeSaved` that we are computing (usually around 1-3s, which is 44% of page load time) is in the right ballpark.

| Site        | Page load (s), Google PSI | Page load, pingdom.com| Page load (s), addon  |
| ------------- |-------------| -----| ----|
| nytimes.com      | 2.5 | 1.2 | 4.4 |
| foxnews.com      | 2.8 | 4.7 | 4.3 |
| amazon.com | 1.6 | 9.3 | 2.9 |