### PR TITLE
Update variation override pref. Fixes #37.

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -20,6 +20,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "Feature",
 this.Bootstrap = {
 
   UI_AVAILABLE_NOTIFICATION: "browser-delayed-startup-finished",
+  VARIATION_OVERRIDE_PREF:
+    "extensions.tracking_protection_messaging_study.variation_override",
   EXPIRATION_DATE_STRING_PREF:
     "extensions.tracking_protection_messaging_study.expiration_date_string",
   STUDY_DURATION_WEEKS: 2,
@@ -101,17 +103,16 @@ this.Bootstrap = {
 
   // helper to let Dev or QA set the variation name
   getVariationFromPref(weightedVariations) {
-    const key = "shield.test.variation";
-    const name = Services.prefs.getCharPref(key, "");
+    const name = Services.prefs.getCharPref(this.VARIATION_OVERRIDE_PREF, "");
     if (name !== "") {
       const variation = weightedVariations.filter(x => x.name === name)[0];
       if (!variation) {
-        throw new Error(`about:config => shield.test.variation set to ${name},
-          but no variation with that name exists`);
+        throw new Error(`about:config => ${this.VARIATION_OVERRIDE_PREF} set to ${name},
+          but no variation with that name exists.`);
       }
       return variation;
     }
-    return name; // undefined
+    return name;
   },
 
   /**

--- a/test/utils.js
+++ b/test/utils.js
@@ -32,6 +32,7 @@ const FIREFOX_PREFERENCES = {
 
   // NECESSARY for all 57+ builds
   "extensions.legacy.enabled": true,
+  "xpinstall.signatures.required": false,
 
   // Temporarily installed addons can break due to sandbox, see Bug #1423687
   "security.sandbox.content.level": 2,


### PR DESCRIPTION
Change `shield.test.variation` override with `extensions.tracking_protection_messaging_study.variation_override` and test to ensure it works.

Steps:
1. Bundle addon files into XPI
2. Open Firefox, make sure `extensions.legacy.enabled` is `true` and `xpinstall.signatures.required` is `false` in `about:config`.
3. In `about:config`, add string pref `extensions.tracking_protection_messaging_study.variation_override` and set its value to the desired variation name; ex: "fast", "private", "control", "pseudo-control".
4. Load the addon in `about:addons` under the Extensions tab.