### PR TITLE
Instrument pageAction panel and confirmation screen.

### DIFF
--- a/addon/content/scripts/page-action-panel.js
+++ b/addon/content/scripts/page-action-panel.js
@@ -7,6 +7,8 @@
 const pageActionPanel = document.getElementById("tracking-protection-study-page-action-panel-box");
 const pageActionButton = document.getElementById("tracking-protection-study-page-action-primary-button");
 const pageActionConfirmationPanel = document.getElementById("tracking-protection-study-page-action-confirmation-panel-box");
+const pageActionConfirmationCancelButton = document.getElementById("tracking-protection-study-confirmation-default-button");
+const pageActionConfirmationDisableButton = document.getElementById("tracking-protection-study-confirmation-secondary-button");
 
 function addCustomContent(data) {
   // TODO: Update strings by messaging branch.
@@ -41,8 +43,8 @@ function onChromeListening() {
   }
 
   pageActionButton.addEventListener("click", handleButtonClick);
-  // confirmationCancelButton.addEventListener("click", handleButtonClick);
-  // confirmationDisableButton.addEventListener("click", handleButtonClick);
+  pageActionConfirmationCancelButton.addEventListener("click", handleButtonClick);
+  pageActionConfirmationDisableButton.addEventListener("click", handleButtonClick);
 
   function handleButtonClick(evt) {
     let event;
@@ -54,13 +56,13 @@ function onChromeListening() {
         resizeBrowser(pageActionConfirmationPanel);
         break;
       case "tracking-protection-study-confirmation-default-button":
-        event = "introduction-confirmation-cancel";
-        confirmationPanel.classList.add("hidden");
-        introPanel.classList.remove("hidden");
-        // TODO add call to browserResize for introPanel
+        event = "page-action-confirmation-cancel";
+        pageActionConfirmationPanel.classList.add("hidden");
+        pageActionPanel.classList.remove("hidden");
+        resizeBrowser(pageActionPanel);
         break;
       case "tracking-protection-study-confirmation-secondary-button":
-        event = "introduction-confirmation-leave-study";
+        event = "page-action-confirmation-leave-study";
         break;
       default:
         throw new Error("Unrecognized UI element: ", evt.target);


### PR DESCRIPTION
![tpstudy_basicpanelux](https://user-images.githubusercontent.com/17437436/35365686-af775cd0-012a-11e8-82ff-a8a343a9d2d8.gif)

Completed the basic UX behavior of the panels finally!

Made `hideIntroPanel` method generic to `hidePanel`, so it can be used for both the intro panel and the pageAction panel, which are really the same `<panel>` with the same `<browser>` element with different `src` values.

Log and send telemetry pings when buttons are pressed and panels are dismissed.

Also I differentiated the "dismiss" behavior between the intro panel and the pageAction panel:
* Intro `<panel>` uses `noautohide` set to `true`.
* pageAction `<panel>` uses `noautohide` set to `false`.
Rationale:
The intro panel has stickier behavior (noautohide = true), since it can be dismissed from a button in the panel itself, and it only shows once and then goes away forever. As a result, I have to manually close it via `panel.hidePopup` on window-close, tab-change, location-change-same-tab
By contrast, the pageAction panel can be accessed any time by clicking the pageAction icon, and it has no button to dismiss it in the panel (only a button to disable Tracking Protection), so it has a behavior of noautohide = false.

TODO:
* Add dynamic data and correct strings based on branch.