### PR TITLE
Add surveys for study endings.

### DIFF
--- a/addon/lib/Config.jsm
+++ b/addon/lib/Config.jsm
@@ -16,7 +16,7 @@ XPCOMUtils.defineLazyModuleGetter(this, "Services", "resource://gre/modules/Serv
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(config|EXPORTED_SYMBOLS)" }]*/
 const EXPORTED_SYMBOLS = ["config"];
 // TODO change testing survey endings to production survey endings
-const SURVEY_URL = "https://qsurvey.mozilla.com/collab/tp-perception";
+const SURVEY_URL = "https://qsurvey.mozilla.com/s3/tp-perception";
 
 const config = {
   PREF_TP_ENABLED_GLOBALLY: "privacy.trackingprotection.enabled",
@@ -51,29 +51,29 @@ const config = {
     "endings": {
       /** standard endings */
       "user-disable": {
-        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-disable`,
+        "baseUrl": `${SURVEY_URL}?reason=user-disable`,
       },
       "ineligible": {
         "baseUrl": null,
       },
       "expired": {
-        "baseUrl": `${SURVEY_URL}?action=eos&reason=expired`,
+        "baseUrl": `${SURVEY_URL}?reason=expired`,
       },
       /** User defined endings */
       "user-disabled-builtin-tracking-protection": {
-        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-disabled-builtin-tracking-protection`,
+        "baseUrl": `${SURVEY_URL}?reason=user-disabled-builtin-tracking-protection`,
         "study_state": "ended-negative",  // neutral is default
       },
       "user-enabled-builtin-tracking-protection": {
-        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-enabled-builtin-tracking-protection`,
+        "baseUrl": `${SURVEY_URL}?reason=user-enabled-builtin-tracking-protection`,
         "study_state": "ended-positive",
       },
       "introduction-confirmation-leave-study": {
-        "baseUrl": `${SURVEY_URL}?action=disable&reason=introduction-confirmation-leave-study`,
+        "baseUrl": `${SURVEY_URL}?reason=introduction-confirmation-leave-study`,
         "study_state": "ended-negative",
       },
       "page-action-confirmation-leave-study": {
-        "baseUrl": `${SURVEY_URL}?action=disable&reason=page-action-confirmation-leave-study`,
+        "baseUrl": `${SURVEY_URL}?reason=page-action-confirmation-leave-study`,
         "study_state": "ended-negative",
       },
     },

--- a/addon/lib/Config.jsm
+++ b/addon/lib/Config.jsm
@@ -13,7 +13,10 @@ const { utils: Cu } = Components;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "Services", "resource://gre/modules/Services.jsm");
 
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "(config|EXPORTED_SYMBOLS)" }]*/
 const EXPORTED_SYMBOLS = ["config"];
+// TODO change testing survey endings to production survey endings
+const SURVEY_URL = "https://qsurvey.mozilla.com/collab/tp-perception";
 
 const config = {
   PREF_TP_ENABLED_GLOBALLY: "privacy.trackingprotection.enabled",
@@ -48,26 +51,30 @@ const config = {
     "endings": {
       /** standard endings */
       "user-disable": {
-        "baseUrl": "http://www.example.com/?reason=user-disable",
+        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-disable`,
       },
       "ineligible": {
-        "baseUrl": "http://www.example.com/?reason=ineligible",
+        "baseUrl": null,
       },
       "expired": {
-        "baseUrl": "http://www.example.com/?reason=expired",
+        "baseUrl": `${SURVEY_URL}?action=eos&reason=expired`,
       },
       /** User defined endings */
-      "used-often": {
-        "baseUrl": "http://www.example.com/?reason=used-often",
-        "study_state": "ended-positive",  // neutral is default
+      "user-disabled-builtin-tracking-protection": {
+        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-disabled-builtin-tracking-protection`,
+        "study_state": "ended-negative",  // neutral is default
       },
-      "a-non-url-opening-ending": {
-        "study_state": "ended-neutral",
-        "baseUrl":  null,
+      "user-enabled-builtin-tracking-protection": {
+        "baseUrl": `${SURVEY_URL}?action=disable&reason=user-enabled-builtin-tracking-protection`,
+        "study_state": "ended-positive",
       },
-      "introduction-leave-study": {
+      "introduction-confirmation-leave-study": {
+        "baseUrl": `${SURVEY_URL}?action=disable&reason=introduction-confirmation-leave-study`,
         "study_state": "ended-negative",
-        "baseUrl": "http://www.example.com/?reason=introduction-leave-study",
+      },
+      "page-action-confirmation-leave-study": {
+        "baseUrl": `${SURVEY_URL}?action=disable&reason=page-action-confirmation-leave-study`,
+        "study_state": "ended-negative",
       },
     },
     "telemetry": {


### PR DESCRIPTION
Tested that the survey opened at the corresponding study ending per `Config.jsm`.

TODO:
* Get adjusted surveys per [this discussion](https://github.com/biancadanforth/tracking-protection-shield-study/issues/23#issuecomment-367151535) from rrayborn.
* Add production survey links when ready to deploy. This would Fix #23.