### PR TITLE
Remove modification of builtin TP UI.

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -64,7 +64,6 @@ class Feature {
     this.DOORHANGER_ID = "onboarding-trackingprotection-notification";
     this.DOORHANGER_ICON = "chrome://browser/skin/tracking-protection-16.svg#enabled";
     this.STYLESHEET_URL = `resource://${STUDY}/skin/tracking-protection-study.css`;
-    this.PREF_TP_UI_ENABLED = "privacy.trackingprotection.ui.enabled";
     this.TP_ENABLED_GLOBALLY = (this.treatment === "pseudo-control");
     this.TP_ENABLED_IN_PRIVATE_WINDOWS = (this.treatment === "control");
     this.PREF_TP_ENABLED_GLOBALLY = "privacy.trackingprotection.enabled";
@@ -78,8 +77,6 @@ class Feature {
     this.initLog(logLevel);
 
     this.addContentMessageListeners();
-
-    this.disableBuiltInTrackingProtectionUI();
 
     // define treatments as STRING: fn(browserWindow, url)
     this.TREATMENTS = {
@@ -193,10 +190,6 @@ class Feature {
       };
       return new ConsoleAPI(consoleOptions);
     });
-  }
-
-  disableBuiltInTrackingProtectionUI() {
-    Services.prefs.setBoolPref(this.PREF_TP_UI_ENABLED, false);
   }
 
   addBuiltInTrackingProtectionListeners() {
@@ -869,12 +862,6 @@ class Feature {
     Cu.unload("resource://tracking-protection-study/BlockLists.jsm");
 
     this.removeBuiltInTrackingProtectionListeners();
-
-    this.reenableBuiltInTrackingProtectionUI();
-  }
-
-  reenableBuiltInTrackingProtectionUI() {
-    Services.prefs.setBoolPref(this.PREF_TP_UI_ENABLED, true);
   }
 
   resetBuiltInTrackingProtection() {


### PR DESCRIPTION
The built-in TP UI pref `privacy.trackingprotection.ui.enabled` doesn't actually control the TP UI in the chrome as initially thought; it only changes the UI for TP in 'about:preferences' from a set of 3 radio buttons to a single checkbox. We actually want the radio buttons enabled, which is the default setting.

`privacy.trackingprotection.ui.enabled = false`
![screen shot 2018-01-26 at 8 07 21 am](https://user-images.githubusercontent.com/17437436/35448814-2a899866-0270-11e8-8fe1-6c5a01146020.png)


`privacy.trackingprotection.ui.enabled = true`
![screen shot 2018-01-26 at 8 06 39 am](https://user-images.githubusercontent.com/17437436/35448796-2074413c-0270-11e8-915d-ea09fa3f4ab7.png)
