### PR TITLE
Tweak timeSaved estimates. Fixes #16.

### DIFF
--- a/addon/content/scripts/page-action-panel.js
+++ b/addon/content/scripts/page-action-panel.js
@@ -34,7 +34,7 @@ function onChromeListening(msg) {
     pageActionFirstQuantity.innerText = msgParsed.firstQuantity;
     let secondQuantityMessage = msgParsed.pageActionQuantities;
     secondQuantityMessage = secondQuantityMessage.replace("${blockedAds}", msgParsed.secondQuantity);
-    secondQuantityMessage = secondQuantityMessage.replace("${timeSaved}", Math.round(msgParsed.secondQuantity / 1000));
+    secondQuantityMessage = secondQuantityMessage.replace("${timeSaved}", Math.ceil(msgParsed.secondQuantity / 1000));
     pageActionSecondQuantity.innerHTML = secondQuantityMessage;
     pageActionMessage.textContent = msgParsed.pageActionMessage;
   }
@@ -89,7 +89,7 @@ function updateTPNumbers(quantities) {
   const treatment = quantities.treatment;
   const firstQuantity = quantities.firstQuantity;
   const secondQuantity = treatment === "fast"
-    ? Math.round(quantities.secondQuantity / 1000)
+    ? Math.ceil(quantities.secondQuantity / 1000)
     : quantities.secondQuantity;
   pageActionFirstQuantity.innerText = firstQuantity;
   let secondQuantityHTML = msgParsed.pageActionQuantities;


### PR DESCRIPTION
There is now a const that can be modified `MAX_TIME_SAVED_FRACTION`. I don't think we want this to go too much higher than it is, otherwise we get situations where we are somehow saving way more time that the page took to load. Ex: I've only been loading the page for 3s and somehow I've already saved 7s.