### PR TITLE
Disable frame scripts on shutdown. Fixes #39.

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -186,13 +186,10 @@ this.Bootstrap = {
     if (isUninstall) {
       // Send this before the ShuttingDown event to ensure that message handlers
       // are still registered and receive it.
-      Services.mm.broadcastAsyncMessage("TPStudy:Uninstalling");
-      // TODO bdanforth: process this message on the other end,
-      // see pioneer-enrollment-study
+      Services.mm.broadcastAsyncMessage("TrackingStudy:Uninstalling");
     }
 
-    Services.mm.broadcastAsyncMessage("TPStudy:ShuttingDown");
-    // TODO bdanforth: process this message on the other end.
+    Services.mm.broadcastAsyncMessage("TrackingStudy:ShuttingDown");
 
     if (isUninstall && !studyUtils._isEnding) {
       // we are the first 'uninstall' requestor => must be user action.

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -152,24 +152,19 @@ class Feature {
 
   addContentMessageListeners() {
     // content listener
-    Services.mm.addMessageListener(
-      "TrackingStudy:OnContentMessage",
-      this.handleMessageFromContent.bind(this)
-    );
+    Services.mm.addMessageListener("TrackingStudy:InitialContent", this);
   }
 
-  handleMessageFromContent(msg) {
-    switch (msg.data.action) {
-      case "get-totals":
-      // TODO bdanforth: update what text is shown based on treatment branch
-      // msg.target is the <browser> element
-        msg.target.messageManager.sendAsyncMessage("TrackingStudy:Totals", {
-          type: "newTabContent",
+  receiveMessage(msg) {
+    switch (msg.name) {
+      case "TrackingStudy:InitialContent":
+        // msg.target is the <browser> element
+        msg.target.messageManager.sendAsyncMessage("TrackingStudy:InitialContent", {
           state: this.state,
         });
         break;
       default:
-        throw new Error(`Message type not recognized, ${ msg.data.action }`);
+        throw new Error(`Message type not recognized, ${ msg.name }`);
     }
   }
 
@@ -722,8 +717,7 @@ class Feature {
         this.state.totalBlockedResources += 1;
         this.state.totalBlockedAds = Math.floor(this.AD_FRACTION * this.state.totalBlockedResources);
 
-        Services.mm.broadcastAsyncMessage("TrackingStudy:Totals", {
-          type: "updateTPNumbers",
+        Services.mm.broadcastAsyncMessage("TrackingStudy:UpdateContent", {
           state: this.state,
         });
         // If the pageAction panel is showing, update the quantities dynamically


### PR DESCRIPTION
![39-disable-frame-scripts](https://user-images.githubusercontent.com/17437436/35548865-232179da-0537-11e8-9862-83234e60cb9a.gif)

A very clean way to do it, courtesy of the [Pioneer Enrollment Study](https://github.com/mozilla/pioneer-enrollment-study/blob/cf928159a00e5b136b5a9ed8c256e2266460ecc0/extension/content/frame-script.js#L40) by osmose.