### PR TITLE
Simplify data passed to frame script. Fixes #79.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -12,6 +12,7 @@ const NEW_TAB_MESSAGE_DIV_ID = "tracking-protection-messaging-study-message";
 class TrackingProtectionStudy {
   constructor(contentWindow) {
     this.contentWindow = contentWindow;
+    this.newTabMessage = "";
     this.init();
   }
 
@@ -34,13 +35,13 @@ class TrackingProtectionStudy {
       case "TrackingStudy:InitialContent":
         // check if document has already loaded
         if (doc.readyState === "complete") {
-          this.addContentToNewTab(msg.data.state, doc);
+          this.addContentToNewTab(msg.data, doc);
         } else {
-          doc.addEventListener("DOMContentLoaded", () => this.addContentToNewTab(msg.data.state, doc));
+          doc.addEventListener("DOMContentLoaded", () => this.addContentToNewTab(msg.data, doc));
         }
         break;
       case "TrackingStudy:UpdateContent":
-        this.updateTPNumbers(msg.data.state, doc);
+        this.updateTPNumbers(msg.data, doc);
         break;
       default:
         throw new Error(`Message name not recognized: ${msg.name}`);
@@ -48,16 +49,18 @@ class TrackingProtectionStudy {
   }
 
   addContentToNewTab(state, doc) {
-    const time = this.getHumanReadableTimeVals(state.totalTimeSaved);
+    const time = this.getHumanReadableTimeVals(state.timeSaved);
 
     // if we haven't blocked anything yet, don't modify the page
-    if (state.totalBlockedResources) {
-      let message = state.newTabMessage;
-      message = message.replace("${blockedRequests}", state.totalBlockedResources);
-      message = message.replace("${blockedAds}", state.totalBlockedAds);
-      message = message.replace("${blockedSites}", state.totalBlockedWebsites);
+    if (state.blockedResources) {
+      this.newTabMessage = state.newTabMessage;
+      // Make a copy of message so we don't mutate the original string, which
+      // we need to preserve for updateTPNumbers.
+      let message = this.newTabMessage;
+      message = message.replace("${blockedRequests}", state.blockedResources);
+      message = message.replace("${blockedAds}", state.blockedAds);
       message = message.replace("${time}", time);
-      
+
       // Check if the study UI has already been added to this page
       const tpContent = doc.getElementById(`${NEW_TAB_CONTAINER_DIV_ID}`);
       if (tpContent) {
@@ -122,13 +125,12 @@ class TrackingProtectionStudy {
   }
 
   updateTPNumbers(state, doc) {
-    const time = this.getHumanReadableTimeVals(state.totalTimeSaved);
+    const time = this.getHumanReadableTimeVals(state.timeSaved);
     const span = doc.getElementById(`${NEW_TAB_MESSAGE_DIV_ID}`);
     if (span) {
-      let message = state.newTabMessage;
-      message = message.replace("${blockedRequests}", state.totalBlockedResources);
-      message = message.replace("${blockedAds}", state.totalBlockedAds);
-      message = message.replace("${blockedSites}", state.totalBlockedWebsites);
+      let message = this.newTabMessage;
+      message = message.replace("${blockedRequests}", state.blockedResources);
+      message = message.replace("${blockedAds}", state.blockedAds);
       message = message.replace("${time}", time);
       span.innerHTML = message;
     }

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -160,7 +160,10 @@ class Feature {
       case "TrackingStudy:InitialContent":
         // msg.target is the <browser> element
         msg.target.messageManager.sendAsyncMessage("TrackingStudy:InitialContent", {
-          state: this.state,
+          blockedResources: this.state.totalBlockedResources,
+          timeSaved: this.state.totalTimeSaved,
+          blockedAds: this.state.totalBlockedAds,
+          newTabMessage: this.newTabMessages[this.treatment],
         });
         break;
       default:
@@ -718,7 +721,9 @@ class Feature {
         this.state.totalBlockedAds = Math.floor(this.AD_FRACTION * this.state.totalBlockedResources);
 
         Services.mm.broadcastAsyncMessage("TrackingStudy:UpdateContent", {
-          state: this.state,
+          blockedResources: this.state.totalBlockedResources,
+          timeSaved: this.state.totalTimeSaved,
+          blockedAds: this.state.totalBlockedAds,
         });
         // If the pageAction panel is showing, update the quantities dynamically
         if (this.state.pageActionPanelIsShowing) {


### PR DESCRIPTION
Instead of passing the entire `state` object of `Feature.jsm` (which included a couple `Map` objects), I now just pass the exact quantities (integers or strings) I need. These string:string or string:int value pairs are JSONable, which eliminate the error message that was being observed.

It should also give us a performance boost! Since we're passing a much smaller amount of data between frame script and JSM.