### PR TITLE
Fix "leaked X window(s)" errors from unit tests

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -40,6 +40,8 @@ this.Bootstrap = {
 
     // choose and set variation
     const variation = await this.selectVariation();
+    this.variation = variation;
+    this.reason = reason;
 
     // if addon was just installed, check if user is eligible
     if ((this.REASONS[reason]) === "ADDON_INSTALL") {
@@ -76,7 +78,7 @@ this.Bootstrap = {
       Services.obs.addObserver(this, this.UI_AVAILABLE_NOTIFICATION);
     } else {
       // TODO bdanforth: check if window is private before adding UI
-      this.addFeature(variation, reason);
+      this.addFeature(this.variation, this.reason);
     }
   },
 
@@ -160,7 +162,7 @@ this.Bootstrap = {
   observe(subject, topic, data) {
     if (topic === this.UI_AVAILABLE_NOTIFICATION) {
       Services.obs.removeObserver(this, this.UI_AVAILABLE_NOTIFICATION);
-      this.addFeature();
+      this.addFeature(this.variation, this.reason);
     }
   },
 

--- a/addon/content/scripts/page-action-panel.js
+++ b/addon/content/scripts/page-action-panel.js
@@ -14,11 +14,12 @@ function onChromeListening(msg) {
 class PageActionPanel {
   constructor(msg) {
     this.msg = msg;
+    this.handleLoadRef = this.handleLoad.bind(this);
+    this.handleButtonClickRef = this.handleButtonClick.bind(this);
 
     if (document.readyState === "complete") {
       this.handleLoad();
     } else {
-      this.handleLoadRef = this.handleLoad.bind(this);
       document.addEventListener("load", this.handleLoadRef);
     }
   }
@@ -68,7 +69,6 @@ class PageActionPanel {
   }
 
   addClickListeners() {
-    this.handleButtonClickRef = this.handleButtonClick.bind(this);
     this.pageActionButton.addEventListener("click", this.handleButtonClickRef);
     this.pageActionConfirmationCancelButton.addEventListener("click", this.handleButtonClickRef);
     this.pageActionConfirmationDisableButton.addEventListener("click", this.handleButtonClickRef);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -288,7 +288,6 @@ class Feature {
     // ensure the frame script is not loaded into any new tabs on shutdown,
     // existing frame scripts already loaded are handled by the bootstrap shutdown method
     CleanupManager.addCleanupHandler(() => Services.mm.removeDelayedFrameScript(this.FRAME_SCRIPT_URL));
-
     // 4. Add pageAction icon and pageAction panel; this is the complicated part
     await this.addPageActionAndPanel(win);
   }
@@ -310,17 +309,17 @@ class Feature {
     // Add listeners to all new windows to know when to update pageAction.
     // Depending on which event happens (ex: onOpenWindow, onLocationChange),
     // it will call that listener method that exists on "this"
-    Services.wm.addListener(this);
+    // Services.wm.addListener(this);
   }
 
   unloadFromWindow(win) {
     this.removeWindowEventListeners(win);
-    Services.wm.removeListener(this);
-    const button = win.document.getElementById(`${this.PAGE_ACTION_BUTTON_ID}`);
-    if (button) {
-      button.removeEventListener("command", (evt) => this.handlePageActionButtonCommand(evt, win));
-      button.parentElement.removeChild(button);
-    }
+    // Services.wm.removeListener(this);
+    // const button = win.document.getElementById(`${this.PAGE_ACTION_BUTTON_ID}`);
+    // if (button) {
+    //   button.removeEventListener("command", (evt) => this.handlePageActionButtonCommand(evt, win));
+    //   button.parentElement.removeChild(button);
+    // }
   }
 
   onWindowError(msg) {
@@ -339,24 +338,24 @@ class Feature {
   addWindowEventListeners(win) {
     if (win && win.gBrowser) {
       win.gBrowser.addTabsProgressListener(this);
-      win.gBrowser.tabContainer.addEventListener(
-        "TabSelect",
-        (evt) => this.onTabChange(evt),
-      );
-      // handle the case where the window closed, but intro or pageAction panel
-      // is still open.
-      win.addEventListener("SSWindowClosing", () => this.handleWindowClosing(win));
+      // win.gBrowser.tabContainer.addEventListener(
+      //   "TabSelect",
+      //   (evt) => this.onTabChange(evt),
+      // );
+      // // handle the case where the window closed, but intro or pageAction panel
+      // // is still open.
+      // win.addEventListener("SSWindowClosing", () => this.handleWindowClosing(win));
     }
   }
 
   removeWindowEventListeners(win) {
     if (win && win.gBrowser) {
       win.gBrowser.removeTabsProgressListener(this);
-      win.gBrowser.tabContainer.removeEventListener(
-        "TabSelect",
-        (evt) => this.onTabChange(evt),
-      );
-      win.removeEventListener("SSWindowClosing", () => this.handleWindowClosing(win));
+      // win.gBrowser.tabContainer.removeEventListener(
+      //   "TabSelect",
+      //   (evt) => this.onTabChange(evt),
+      // );
+      // win.removeEventListener("SSWindowClosing", () => this.handleWindowClosing(win));
     }
   }
 

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -319,12 +319,12 @@ class Feature {
     // Add listeners to all new windows to know when to update pageAction.
     // Depending on which event happens (ex: onOpenWindow, onLocationChange),
     // it will call that listener method that exists on "this"
-    Services.wm.addListener(this);
+    // Services.wm.addListener(this);
   }
 
   unloadFromWindow(win) {
     this.removeWindowEventListeners(win);
-    Services.wm.removeListener(this);
+    // Services.wm.removeListener(this);
     const pageActionButton = win.document.getElementById(`${this.PAGE_ACTION_BUTTON_ID}`);
     if (pageActionButton) {
       pageActionButton.removeEventListener("command", this.handlePageActionButtonCommandRef);
@@ -348,24 +348,24 @@ class Feature {
   addWindowEventListeners(win) {
     if (win && win.gBrowser) {
       win.gBrowser.addTabsProgressListener(this);
-      win.gBrowser.tabContainer.addEventListener(
-        "TabSelect",
-        this.onTabChangeRef,
-      );
-      // handle the case where the window closed, but intro or pageAction panel
-      // is still open.
-      win.addEventListener("SSWindowClosing", this.handleWindowClosingRef);
+      // win.gBrowser.tabContainer.addEventListener(
+      //   "TabSelect",
+      //   this.onTabChangeRef,
+      // );
+      // // handle the case where the window closed, but intro or pageAction panel
+      // // is still open.
+      // win.addEventListener("SSWindowClosing", this.handleWindowClosingRef);
     }
   }
 
   removeWindowEventListeners(win) {
     if (win && win.gBrowser) {
       win.gBrowser.removeTabsProgressListener(this);
-      win.gBrowser.tabContainer.removeEventListener(
-        "TabSelect",
-        this.onTabChangeRef,
-      );
-      win.removeEventListener("SSWindowClosing", this.handleWindowClosingRef);
+      // win.gBrowser.tabContainer.removeEventListener(
+      //   "TabSelect",
+      //   this.onTabChangeRef,
+      // );
+      // win.removeEventListener("SSWindowClosing", this.handleWindowClosingRef);
     }
   }
 
@@ -400,7 +400,7 @@ class Feature {
       this.state.timeSaved.set(browser, 0);
 
       // Hide intro panel on location change in the same tab if showing
-      if (this.state.introPanelIsShowing && this.introPanelBrowser === browser) {
+      if (this.state.introPanelIsShowing && this.weakIntroPanelBrowser.get() === browser) {
         this.hidePanel("location-change-same-tab", true);
       }
       if (this.state.pageActionPanelIsShowing) {
@@ -409,7 +409,7 @@ class Feature {
     }
 
     if (this.shouldShowIntroPanel) {
-      this.introPanelBrowser = browser;
+      this.weakIntroPanelBrowser = Cu.getWeakReference(browser);
     }
   }
 
@@ -988,6 +988,7 @@ class Feature {
 
     // Remove all references to DOMWindow objects and their descendants
     delete this.introPanel;
+    delete this.weakIntroPanelBrowser;
     delete this.introPanelChromeWindow;
     delete this.pageActionPanel;
     delete this.pageActionPanelChromeWindow;

--- a/addon/lib/WindowWatcher.jsm
+++ b/addon/lib/WindowWatcher.jsm
@@ -61,7 +61,7 @@ class WindowWatcherClass {
       try {
         this._loadCallback(win);
       } catch (ex) {
-        this._onError("WindowWatcher code loading callback failed: ", ex);
+        this._onError(`WindowWatcher code loading callback failed: ${ex}`);
       }
     }
 

--- a/bin/mach-test.sh
+++ b/bin/mach-test.sh
@@ -1,8 +1,0 @@
-# Copying build-includes into dist/${ADDON_NAME}/ for testing in tree
-BASE_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"
-ADDON_NAME=$(node -p -e "require('./package.json').name");
-mkdir -p dist/$ADDON_NAME
-while read -r LINE || [[ -n "${LINE}" ]]; do
-  mkdir -p "$(dirname "dist/${ADDON_NAME}/${LINE}")"
-  cp -r "${BASE_DIR}/addon/${LINE}" "$(dirname "dist/${ADDON_NAME}/${LINE}")"
-done < "${BASE_DIR}/build-includes.txt"

--- a/bin/test-in-tree.sh
+++ b/bin/test-in-tree.sh
@@ -1,0 +1,59 @@
+# This script automates the process of testing your Shield study addon locally
+# for a given unit test.
+# It takes the state of your addon's working directory in your GitHub repo and
+# drops it into your local Firefox development directory. You do not need to
+# commit any changes in Git or Hg to perform local testing.
+
+# IMPORTANT: READ BEFORE USING - ASSUMPTIONS MADE FOR THIS SCRIPT TO WORK
+# **You have added your shield study ID to the list of DIRS in ./browser/extensions/moz.build in the Hg repo
+# **You have a jar.mn and moz.build file inside your ./addon folder in your Git repo
+# You are testing against the "release" channel
+# You have recently built the "release" branch of Firefox
+#   (`hg pull -u release` > [`./mach clobber`] > `./mach build`)
+#   in your local Firefox directory
+# Your local Firefox directory is located at: $FIREFOX_LOCAL_DIR
+#  If not, update the value of that variable in this script.
+# The unit test you want to run is located at: $UNIT_TEST_RELATIVE_PATH
+#  If not, update the value of that variable in this script.
+
+# **: For more detailed instructions, see:
+# https://github.com/biancadanforth/tracking-protection-shield-study/pull/12#issuecomment-356196425
+
+# Note: If you are checking for memory leaks, make sure you are building a "debug" build
+# https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Configuring_Build_Options
+
+# Step 1: Copying build-includes into dist/${ADDON_NAME}/ for testing in tree
+echo "NPM RUN TEST: Copying addon files to a folder in ./dist..."
+BASE_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"
+ADDON_NAME=$(node -p -e "require('./package.json').name");
+mkdir -p dist/$ADDON_NAME
+while read -r LINE || [[ -n "${LINE}" ]]; do
+  mkdir -p "$(dirname "dist/${ADDON_NAME}/${LINE}")"
+  cp -r "${BASE_DIR}/addon/${LINE}" "$(dirname "dist/${ADDON_NAME}/${LINE}")"
+done < "${BASE_DIR}/build-includes.txt"
+
+# Step 2: Copies over the folder made in Step 1 into the tree, ./browser/extensions
+echo "NPM RUN TEST: Copying that folder into your local copy of Firefox..."
+FIREFOX_LOCAL_DIR=$HOME/src/mozilla-unified
+FIREFOX_LOCAL_ADDON_DIR=$FIREFOX_LOCAL_DIR/browser/extensions
+cp -r dist/"${ADDON_NAME}" "${FIREFOX_LOCAL_ADDON_DIR}"
+
+# Step 3: Change directories in the terminal to location for mozilla-unified
+pushd ${FIREFOX_LOCAL_DIR} > /dev/null
+
+# Step 4: Fetch latest changes from branch of interest, e.g. release
+echo "NPM RUN TEST: Fetching latest changes for the release branch of Firefox..."
+hg pull -u release
+
+# Step 5: Build Firefox with this patch
+echo "NPM RUN TEST: Building a local copy of Firefox..."
+./mach build faster
+
+# Step 6: Run the test of interest
+UNIT_TEST_RELATIVE_PATH="devtools/client/responsive.html/test/browser/browser_viewport_basics.js"
+echo "NPM RUN TEST: Running the test at ${UNIT_TEST_RELATIVE_PATH}..."
+./mach mochitest $UNIT_TEST_RELATIVE_PATH
+
+# Step 7: Change directories back to GitHub repo
+echo "NPM RUN TEST: Exiting..."
+trap "popd > /dev/null" EXIT

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "url": "git://github.com/biancadanforth/tracking-protection-shield-study.git"
   },
   "scripts": {
-    "build": "bash ./bin/xpi.sh ; bash ./bin/mach-test.sh",
+    "build": "bash ./bin/xpi.sh",
     "eslint": "eslint addon test --ext jsm --ext js --ext json",
     "firefox": "export XPI=dist/linked-addon.xpi && export FIREFOX_BINARY=/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin && npm run build && node run-firefox.js",
     "harness_test": "export XPI=dist/linked-addon.xpi && mocha test/functional_tests.js --retry 2 --reporter json",
@@ -71,7 +71,7 @@
     "lint:nsp": "nsp check",
     "prebuild": "cp node_modules/shield-studies-addon-utils/dist/StudyUtils.jsm addon/",
     "sign": "echo 'TBD, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1407757'",
-    "test": "export XPI=dist/linked-addon.xpi && npm run build && mocha test/functional_tests.js --retry 2",
+    "test": "bash ./bin/test-in-tree.sh",
     "watch": "onchange 'addon/**' 'package.json' 'template/**' -e addon/install.rdf -e addon/chrome.manifest -e addon/StudyUtils.jsm -- npm run build -- '{{event}} {{changed}} $(date)'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "bash ./bin/xpi.sh ; bash ./bin/mach-test.sh",
     "eslint": "eslint addon test --ext jsm --ext js --ext json",
-    "firefox": "export XPI=dist/linked-addon.xpi && npm run build && node run-firefox.js",
+    "firefox": "export XPI=dist/linked-addon.xpi && export FIREFOX_BINARY=/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin && npm run build && node run-firefox.js",
     "harness_test": "export XPI=dist/linked-addon.xpi && mocha test/functional_tests.js --retry 2 --reporter json",
     "lint": "npm-run-all lint:*",
     "lint:addons-linter": "# actually a post build test:  bin/addonLintTest ' + require('./package.json').name",


### PR DESCRIPTION
This is the start of a fix for #88.

FIXED: The addTabsProgressListener now removes itself from the initial window if it closes BEFORE Feature.uninit (i.e. WindowWatcher.stop) is called. So now, we get mTabsProgressListeners.length down to 0 when that window is closed instead of 1.
Reason: We were previously not handling the onWindowClose event in the WindowWatcher observe function -- Are event listeners on windows automatically removed on window close? NO.

Also ensures the addTabsProgressListener is added to any newly created windows.

Currently the code is bisected (i.e a large chunk is commented out) for leak debugging purposes. It gets as far into Feature.jsm as `addTabsProgressListener` and into a portion of its listener `onLocationChange`.