### PR TITLE
Ensure consistent quantities across all study UI. Fixes #58.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -87,13 +87,13 @@ class TrackingProtectionStudy {
     }
   }
 
-  // timeSaved comes in as ms
+  // timeSaved comes in as s
   getHumanReadableTimeVals(timeSaved) {
     let timeStr = "";
     let timeSeconds,
       timeMinutes,
       timeHours;
-    timeSeconds = timeSaved / 1000;
+    timeSeconds = timeSaved;
     if (timeSeconds >= 60) {
       timeMinutes = timeSeconds / 60;
       timeSeconds = (timeMinutes % 1) * 60;

--- a/addon/content/scripts/page-action-panel.js
+++ b/addon/content/scripts/page-action-panel.js
@@ -101,7 +101,7 @@ class PageActionPanel {
   getHumanReadableTime(perPageTimeSaved) {
     let timeSaved = "";
     let timeUnit = "";
-    const timeSeconds = perPageTimeSaved / 1000;
+    const timeSeconds = Math.ceil(perPageTimeSaved / 1000);
     if (timeSeconds >= 60) {
       const timeMinutes = timeSeconds / 60;
       timeSaved += `${timeMinutes.toFixed(2)}`;
@@ -110,9 +110,9 @@ class PageActionPanel {
         timeUnit += "s";
       }
     } else {
-      timeSaved += `${Math.round(timeSeconds)}`;
+      timeSaved += timeSeconds;
       timeUnit += "second";
-      if (Math.round(timeSeconds) !== 1) {
+      if (timeSeconds !== 1) {
         timeUnit += "s";
       }
     }

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -835,15 +835,19 @@ class Feature {
         // If we get this far, we're going to block the request
         counter++;
         this.state.blockedResources.set(details.browser, counter);
-        this.state.blockedAds.set(details.browser, Math.floor(this.AD_FRACTION * counter));
         const timeSavedThisRequest = Math.min(Math.random() * (counter) * 1000, this.MAX_TIME_SAVED_FRACTION * counter * 1000);
         const timeSavedLastRequest = this.state.timeSaved.get(details.browser);
         if (timeSavedThisRequest > timeSavedLastRequest) {
           this.state.timeSaved.set(details.browser, timeSavedThisRequest);
-          this.state.totalTimeSaved += (timeSavedThisRequest - timeSavedLastRequest);
+          this.state.totalTimeSaved -= Math.ceil(timeSavedLastRequest / 1000);
+          this.state.totalTimeSaved += Math.ceil(timeSavedThisRequest / 1000);
         }
         this.state.totalBlockedResources += 1;
-        this.state.totalBlockedAds = Math.floor(this.AD_FRACTION * this.state.totalBlockedResources);
+        const adsBlockedLastRequest = this.state.blockedAds.get(details.browser);
+        const adsBlockedThisRequest = Math.floor(this.AD_FRACTION * counter);
+        this.state.totalBlockedAds -= Math.floor(adsBlockedLastRequest);
+        this.state.totalBlockedAds += Math.floor(adsBlockedThisRequest);
+        this.state.blockedAds.set(details.browser, Math.floor(this.AD_FRACTION * counter));
 
         Services.mm.broadcastAsyncMessage("TrackingStudy:UpdateContent", {
           blockedResources: this.state.totalBlockedResources,


### PR DESCRIPTION
I use `Math.ceil` consistently for per-page totals on time saved and total time saved.
I make sure to sum rounded totals for `totalTimeSaved` and `totalBlockedAds` instead of rounding the sum at the end.
@pdehaan Can you try this out and see if this fixes #58?