### PR TITLE
Leave user alone in PB mode. Fixes #86.

### DIFF
--- a/addon/content/aboutPrivateBrowsingMod.xhtml
+++ b/addon/content/aboutPrivateBrowsingMod.xhtml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<!DOCTYPE html [
+  <!ENTITY % htmlDTD PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "DTD/xhtml1-strict.dtd">
+  %htmlDTD;
+  <!ENTITY % globalDTD SYSTEM "chrome://global/locale/global.dtd">
+  %globalDTD;
+  <!ENTITY % brandDTD SYSTEM "chrome://branding/locale/brand.dtd">
+  %brandDTD;
+  <!ENTITY % browserDTD SYSTEM "chrome://browser/locale/browser.dtd">
+  %browserDTD;
+  <!ENTITY % aboutPrivateBrowsingDTD SYSTEM "chrome://browser/locale/aboutPrivateBrowsing.dtd">
+  %aboutPrivateBrowsingDTD;
+]>
+
+<html xmlns="http://www.w3.org/1999/xhtml" class="private">
+  <head>
+    <link id="favicon" rel="icon" type="image/png" href="chrome://browser/skin/privatebrowsing/favicon.svg"/>
+    <link rel="stylesheet" href="chrome://browser/content/aboutPrivateBrowsing.css" type="text/css" media="all"/>
+    <link rel="stylesheet" href="chrome://browser/skin/privatebrowsing/aboutPrivateBrowsing.css" type="text/css" media="all"/>
+    <script type="application/javascript" src="chrome://browser/content/aboutPrivateBrowsing.js"></script>
+  </head>
+
+  <body dir="&locale.dir;">
+    <p class="showNormal">&aboutPrivateBrowsing.notPrivate;</p>
+    <button xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+            id="startPrivateBrowsing"
+            class="showNormal"
+            label="&privatebrowsingpage.openPrivateWindow.label;"
+            accesskey="&privatebrowsingpage.openPrivateWindow.accesskey;"/>
+    <div class="showPrivate container">
+      <h1 class="title">
+        <!-- <span id="title">&privateBrowsing.title;</span> -->
+        <span id="titleTracking">&privateBrowsing.title.tracking;</span>
+      </h1>
+      <section class="section-main">
+        <p>&aboutPrivateBrowsing.info.notsaved.before;<strong>&aboutPrivateBrowsing.info.notsaved.emphasize;</strong>&aboutPrivateBrowsing.info.notsaved.after;</p>
+        <div class="list-row">
+          <ul>
+            <li>&aboutPrivateBrowsing.info.visited;</li>
+            <li>&aboutPrivateBrowsing.info.cookies;</li>
+            <li>&aboutPrivateBrowsing.info.searches;</li>
+            <li>&aboutPrivateBrowsing.info.temporaryFiles;</li>
+          </ul>
+        </div>
+        <p>&aboutPrivateBrowsing.info.saved.before;<strong>&aboutPrivateBrowsing.info.saved.emphasize;</strong>&aboutPrivateBrowsing.info.saved.after2;</p>
+        <div class="list-row">
+          <ul>
+            <li>&aboutPrivateBrowsing.info.bookmarks;</li>
+            <li>&aboutPrivateBrowsing.info.downloads;</li>
+          </ul>
+        </div>
+        <p>&aboutPrivateBrowsing.note.before;<strong>&aboutPrivateBrowsing.note.emphasize;</strong>&aboutPrivateBrowsing.note.after;</p>
+      </section>
+
+      <h2 id="tpSubHeader" class="about-subheader">
+        <span class="tpTitle">&trackingProtection.title;</span>
+<!--         <input id="tpToggle" class="toggle toggle-input" type="checkbox"/> -->
+<!--         <span id="tpButton" class="toggle-btn"></span> -->
+      </h2>
+
+      <section class="section-main">
+        <p>&trackingProtection.description2;</p>
+      </section>
+
+<!--       <section class="section-main">
+        <p class="about-info">&aboutPrivateBrowsing.learnMore3.before;<a id="learnMore" target="_blank">&aboutPrivateBrowsing.learnMore3.title;</a>&aboutPrivateBrowsing.learnMore3.after;</p>
+      </section> -->
+
+    </div>
+  </body>
+</html>

--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -159,12 +159,19 @@ class TrackingProtectionStudy {
 addEventListener("load", handleLoad, true);
 
 function handleLoad(evt) {
-  const window = evt.target.defaultView;
-  const location = window.location.href;
+  const win = evt.target.defaultView;
+  const location = win.location.href;
   if (location === ABOUT_NEWTAB_URL || location === ABOUT_HOME_URL) {
+
+    Components.utils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
+    // Don't show new tab page variation in a Private Browsing window
+    if (PrivateBrowsingUtils.isContentWindowPrivate(win)) {
+      return;
+    }
+
     // queues a function to be called during a browser's idle periods
-    window.requestIdleCallback(() => {
-      new TrackingProtectionStudy(window);
+    win.requestIdleCallback(() => {
+      new TrackingProtectionStudy(win);
       sendAsyncMessage("TrackingStudy:InitialContent");
     });
   }

--- a/templates/chrome.manifest.mustache
+++ b/templates/chrome.manifest.mustache
@@ -5,3 +5,5 @@ resource {{addon.chromeResource}} .
 {{! # source for the addon icon }}
 content {{addon.chromeResource}}-icons .
 
+override chrome://browser/content/aboutPrivateBrowsing.xhtml resource://{{addon.chromeResource}}/content/aboutPrivateBrowsingMod.xhtml
+


### PR DESCRIPTION
### TODO before merge: get jsavory's feedback on modified `about:privatebrowsing` page.

Basically there were 3 main entry points where UI could be added in a private window:
1. Inside WindowWatchers.jsm; I now check for PB mode and don't add any window listeners to existing or new windows that are private.
2. Inside WebRequest.onBeforeRequest: I now check for PB mode and don't call showPageAction or setPageActionCounter in private windows.
3. Inside every frame script (Services.mm.loadFrameScript()); I now check for PB mode before any new tab page content is added.

Added 'win' argument to setPageActionCounter and showPageAction methods to check for PB mode within, as there are cases when both a private and non-private window are open and these methods can get called from the non-private window.

Though there is no UI in PB and no data collection, we do still block requests in PB and those blocked resources/ads/time saved quantities get added to the session totals visible in non-PB mode new tab pages.

### Before:
![86-beforepbmode](https://user-images.githubusercontent.com/17437436/36520836-559f15a2-1748-11e8-861e-7f48ee80d177.gif)

### After:
![86-afterpbmode](https://user-images.githubusercontent.com/17437436/36520919-bbff1432-1748-11e8-88bc-122c007f3e1e.gif)

Also I noticed that in private windows, the 'new tab' page is 'about:privatebrowsing' instead of 'about:newtab'. This page shows users in our experimental branch (where we tell them TP is on) that TP is off. This can be confusing, and I should check and see if there's an easy way to override the new tab page in PB mode.

### Before:
![screen shot 2018-02-21 at 8 44 49 pm](https://user-images.githubusercontent.com/17437436/36520808-2e042582-1748-11e8-936f-daf2877acfff.png)

### After:
![screen shot 2018-02-21 at 8 31 37 pm](https://user-images.githubusercontent.com/17437436/36520815-33d79872-1748-11e8-91b9-a53962ca0684.png)
