### PR TITLE
Ensure pageAction quantities are initialized to 0. Fixes #98.

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -589,10 +589,10 @@ class Feature {
   }
 
   updateQuantities(browser) {
-    const firstQuantity = this.state.blockedResources.get(browser);
+    const firstQuantity = this.state.blockedResources.get(browser) || 0;
     const secondQuantity = this.treatment === "fast"
-      ? this.state.timeSaved.get(browser)
-      : this.state.blockedAds.get(browser);
+      ? this.state.timeSaved.get(browser) || 0
+      : this.state.blockedAds.get(browser) || 0;
     // Let the page script know it can now send messages to JSMs,
     // since sendMessageToChrome has been exported
     this.weakEmbeddedBrowser.get().contentWindow.wrappedJSObject


### PR DESCRIPTION
This PR will fix #98.

* Fixed a bug where the pageAction button and intro panel were still showing on `about:*` pages after a location change in the same tab.
* Cleaned up and clarified onLocationChange method logic in Feature.jsm.
* Initialize pageAction quantities to 0 if not found in per-page `WeakMap` objects `this.state.blockedResources`, `this.state.blockedAds` and `this.state.timeSaved`.