### PR TITLE
Don't prematurely dismiss intro panel on window blur. Fixes #111.

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -422,8 +422,9 @@ class Feature {
 
     // if we got this far, this is an http(s) page; show pageAction and
     // reset per-page quantities
-    this.showPageAction(doc);
-    this.setPageActionCounter(doc, 0);
+    const win = browser.ownerGlobal;
+    this.showPageAction(doc, win);
+    this.setPageActionCounter(doc, 0, win);
     this.state.blockedResources.set(browser, 0);
     this.state.blockedAds.set(browser, 0);
     this.state.timeSaved.set(browser, 0);


### PR DESCRIPTION
The panel no longer gets dismissed prematurely. It is correctly dismissed when a new window is opened. It is correctly dismissed when the user switches to an existing window.