### PR TITLE
Initialize any quantity obtained from a WeakMap to 0. Fixes #117.

### DIFF
--- a/addon/content/aboutPrivateBrowsingMod.xhtml
+++ b/addon/content/aboutPrivateBrowsingMod.xhtml
@@ -34,7 +34,7 @@
             accesskey="&privatebrowsingpage.openPrivateWindow.accesskey;"/>
     <div class="showPrivate container">
       <h1 class="title">
-        <!-- <span id="title">&privateBrowsing.title;</span> -->
+        <span id="title">&privateBrowsing.title;</span>
         <span id="titleTracking">&privateBrowsing.title.tracking;</span>
       </h1>
       <section class="section-main">
@@ -59,17 +59,20 @@
 
       <h2 id="tpSubHeader" class="about-subheader">
         <span class="tpTitle">&trackingProtection.title;</span>
-<!--         <input id="tpToggle" class="toggle toggle-input" type="checkbox"/> -->
-<!--         <span id="tpButton" class="toggle-btn"></span> -->
+        <input id="tpToggle" style="display:none;" class="toggle toggle-input" type="checkbox"/>
+        <span id="tpButton" style="display:none;" class="toggle-btn"></span>
       </h2>
 
       <section class="section-main">
         <p>&trackingProtection.description2;</p>
+        <p>
+          <a id="startTour" style="display:none;" class="button">&trackingProtection.startTour1;</a>
+        </p>
       </section>
 
-<!--       <section class="section-main">
+      <section class="section-main">
         <p class="about-info">&aboutPrivateBrowsing.learnMore3.before;<a id="learnMore" target="_blank">&aboutPrivateBrowsing.learnMore3.title;</a>&aboutPrivateBrowsing.learnMore3.after;</p>
-      </section> -->
+      </section>
 
     </div>
   </body>

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -1075,6 +1075,7 @@ class Feature {
           blockedResources: this.state.totalBlockedResources,
           timeSaved: this.state.totalTimeSaved,
           blockedAds: this.state.totalBlockedAds,
+          newTabMessage: this.newTabMessages[this.treatment],
         });
         // If the pageAction panel is showing, update the quantities dynamically
         if (this.state.pageActionPanelIsShowing) {

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -571,8 +571,8 @@ class Feature {
       // depending on the treatment branch, we want the count of timeSaved
       // ("fast") or blockedResources ("private")
       let counter = this.treatment === "private" ?
-        this.state.blockedResources.get(win.gBrowser.selectedBrowser) :
-        this.state.timeSaved.get(win.gBrowser.selectedBrowser);
+        this.state.blockedResources.get(win.gBrowser.selectedBrowser) || 0 :
+        this.state.timeSaved.get(win.gBrowser.selectedBrowser) || 0;
       if (!counter) {
         counter = 0;
       }
@@ -1031,10 +1031,7 @@ class Feature {
       // Block third-party requests only.
       if (currentHost !== host
         && blocklists.hostInBlocklist(this.lists.blocklist, host)) {
-        let counter = 0;
-        if (this.state.blockedResources.has(details.browser)) {
-          counter = this.state.blockedResources.get(details.browser);
-        }
+        let counter = this.state.blockedResources.get(details.browser) || 0;
 
         const rootDomainHost = this.getRootDomain(host);
         const rootDomainCurrentHost = this.getRootDomain(currentHost);
@@ -1069,12 +1066,11 @@ class Feature {
           this.state.totalTimeSaved += Math.ceil(timeSavedThisRequest / 1000);
         }
         this.state.totalBlockedResources += 1;
-        const adsBlockedLastRequest = this.state.blockedAds.get(details.browser);
+        const adsBlockedLastRequest = this.state.blockedAds.get(details.browser) || 0;
         const adsBlockedThisRequest = Math.floor(this.AD_FRACTION * counter);
         this.state.totalBlockedAds -= Math.floor(adsBlockedLastRequest);
         this.state.totalBlockedAds += Math.floor(adsBlockedThisRequest);
         this.state.blockedAds.set(details.browser, Math.floor(this.AD_FRACTION * counter));
-
         Services.mm.broadcastAsyncMessage("TrackingStudy:UpdateContent", {
           blockedResources: this.state.totalBlockedResources,
           timeSaved: this.state.totalTimeSaved,
@@ -1084,8 +1080,8 @@ class Feature {
         if (this.state.pageActionPanelIsShowing) {
           const firstQuantity = counter;
           const secondQuantity = this.treatment === "fast"
-            ? this.state.timeSaved.get(details.browser)
-            : this.state.blockedAds.get(details.browser);
+            ? this.state.timeSaved.get(details.browser) || 0
+            : this.state.blockedAds.get(details.browser) || 0;
           this.weakEmbeddedBrowser.get().contentWindow.wrappedJSObject
             .updateTPNumbers(JSON.stringify({
               treatment: this.treatment,
@@ -1110,8 +1106,11 @@ class Feature {
           // "private" treatment branch, otherwise we want to display timeSaved
           // for the "fast" treatment branch
           if (details.browser === win.gBrowser.selectedBrowser) {
+            const badgeValue = this.treatment === "private"
+              ? counter
+              : this.state.timeSaved.get(details.browser) || 0;
             this.showPageAction(browser.getRootNode(), win);
-            this.setPageActionCounter(browser.getRootNode(), this.treatment === "private" ? counter : this.state.timeSaved.get(details.browser), win);
+            this.setPageActionCounter(browser.getRootNode(), badgeValue, win);
           }
         }
         return BLOCK_THE_REQUEST;
@@ -1180,8 +1179,8 @@ class Feature {
       
       // record page action click event and badge count
       let counter = this.treatment === "private" ?
-        this.state.blockedResources.get(win.gBrowser.selectedBrowser) :
-        Math.ceil(this.state.timeSaved.get(win.gBrowser.selectedBrowser) / 1000);
+        this.state.blockedResources.get(win.gBrowser.selectedBrowser) || 0 :
+        Math.ceil((this.state.timeSaved.get(win.gBrowser.selectedBrowser) || 0) / 1000);
 
       Storage.get("behavior-summary").then((behaviorSummary) => {
         let clicks = Number(behaviorSummary.badge_clicks) + 1;


### PR DESCRIPTION
Prevents `undefined` and `NaN` showing up in `about:newtab` or anywhere else.