### PR TITLE
Prevent new tab mod from showing on other pages. Fixes #132.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -17,6 +17,7 @@ class TrackingProtectionStudy {
     this.newTabMessage = "";
     this.sendOpenTimeRef = this.sendOpenTime.bind(this);
     this.RADIX = 10; // numerical base for parseInt
+    this.shouldAddNewTabContent = true;
     this.init();
   }
 
@@ -25,6 +26,7 @@ class TrackingProtectionStudy {
     addMessageListener("TrackingStudy:UpdateContent", this);
     addMessageListener("TrackingStudy:ShuttingDown", this);
     addMessageListener("TrackingStudy:Uninstalling", this);
+    addMessageListener("TrackingStudy:OnLocationChange", this);
 
     this.initTimer();
   }
@@ -43,6 +45,13 @@ class TrackingProtectionStudy {
     const doc = this.contentWindow.document;
     this.addContentToNewTabRef = () => this.addContentToNewTab(msg.data, doc);
     switch (msg.name) {
+      case "TrackingStudy:OnLocationChange":
+        if (msg.data.location !== this.ABOUT_HOME_URL || msg.data.location !== this.ABOUT_NEWTAB_URL) {
+          this.shouldAddNewTabContent = false;
+          return;
+        }
+        this.shouldAddNewTabContent = true;
+        break;
       case "TrackingStudy:ShuttingDown":
         this.onShutdown();
         break;
@@ -66,6 +75,10 @@ class TrackingProtectionStudy {
   }
 
   addContentToNewTab(state, doc) {
+    if (!this.shouldAddNewTabContent) {
+      return;
+    }
+
     // if we haven't blocked anything yet, don't modify the page
     if (state.blockedResources) {
       this.newTabMessage = state.newTabMessage;

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -526,6 +526,10 @@ class Feature {
       return;
     }
 
+    // Let frame script know that the location has changed, so it doesn't add
+    // about:newtab mod to other pages
+    browser.messageManager.sendAsyncMessage("TrackingStudy:OnLocationChange", { location: uri.spec });
+
     // Hide panels on location change in the same tab if showing
     if (this.state.introPanelIsShowing && this.weakIntroPanelBrowser.get() === browser) {
       this.hidePanel("location-change-same-tab", true);


### PR DESCRIPTION
I was adding the new tab content indiscriminately, regardless if the location changed from 'about:newtab' to something else later on.

I fixed this by adding a check onLocationChange to check the location before adding new tab content.

@pdehaan : I claim this fixes the bug you were also seeing in #136 . Can you try this out and confirm?