### PR TITLE
Convert ad/blocked resource session totals to locale string. Fixes #131.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -144,8 +144,15 @@ class TrackingProtectionStudy {
       parseInt(state.timeSaved, this.RADIX)
     );
     let message = this.newTabMessage;
-    message = message.replace("${blockedRequests}", parseInt(state.blockedResources, this.RADIX));
-    message = message.replace("${blockedAds}", parseInt(state.blockedAds, this.RADIX));
+    // toLocaleString adds ',' for large number values; ex: 1000 will become 1,000.
+    message = message.replace(
+      "${blockedRequests}",
+      parseInt(state.blockedResources, this.RADIX).toLocaleString()
+    );
+    message = message.replace(
+      "${blockedAds}",
+      parseInt(state.blockedAds, this.RADIX).toLocaleString()
+    );
     message = message.replace("${time}", parsedTime);
     return message;
   }


### PR DESCRIPTION
Adds commas for large quantities. Ex: 1000 becomes 1,000.

<img width="778" alt="screen shot 2018-03-06 at 3 04 49 pm" src="https://user-images.githubusercontent.com/17437436/37064150-a82ea046-2150-11e8-9dee-835325526225.png">
Thanks @pdehaan for the tip here; saved me some time in sorting this out!