### PR TITLE
Correctly get topmost window to update pageAction and its panel. Fixe…

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -499,6 +499,9 @@ class Feature {
       && win === this.weakIntroPanelChromeWindow.get()) {
       this.hidePanel("window-deactivate", true);
     }
+    if (this.state.pageActionPanelIsShowing) {
+      this.hidePanel("window-deactivate", false);
+    }
   }
 
   handleWindowClosing(win) {

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -173,10 +173,7 @@ class Feature {
     };
 
     // run once now on the most recent window.
-    const win = RecentWindow.getMostRecentBrowserWindow({
-      private: false,
-      allowPopups: false,
-    });
+    const win = this.getMostRecentWindow();
 
     /*
     * Note: Why we are using <browser> as the key in each WeakMap in this.state:
@@ -223,6 +220,13 @@ class Feature {
 
     CleanupManager.addCleanupHandler(() => Services.mm.removeMessageListener("TrackingStudy:InitialContent", this));
     CleanupManager.addCleanupHandler(() => Services.mm.removeMessageListener("TrackingStudy:NewTabOpenTime", this));
+  }
+
+  getMostRecentWindow() {
+    return RecentWindow.getMostRecentBrowserWindow({
+      private: false,
+      allowPopups: false,
+    });
   }
 
   async receiveMessage(msg) {
@@ -602,10 +606,7 @@ class Feature {
       return;
     }
 
-    const currentWin = RecentWindow.getMostRecentBrowserWindow({
-      private: false,
-      allowPopups: false,
-    });
+    const currentWin = this.getMostRecentWindow();
 
     // If user changes tabs but stays within current window we want to update
     // the status of the pageAction, then reshow it if the new page has had any
@@ -741,10 +742,7 @@ class Feature {
       { defineAs: "sendMessageToChrome"}
     );
     // Get the quantities for the pageAction panel for the current page
-    const win = RecentWindow.getMostRecentBrowserWindow({
-      private: false,
-      allowPopups: false,
-    });
+    const win = this.getMostRecentWindow();
     if (win.gBrowser.selectedBrowser) {
       const browser = win.gBrowser.selectedBrowser;
       this.updateQuantities(browser);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -56,6 +56,8 @@ XPCOMUtils.defineLazyServiceGetter(this, "styleSheetService",
   "@mozilla.org/content/style-sheet-service;1", "nsIStyleSheetService");
 XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
   "resource://gre/modules/PrivateBrowsingUtils.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "RecentWindow",
+"resource:///modules/RecentWindow.jsm");
 // Import URL Web API into module
 Cu.importGlobalProperties(["URL"]);
 // Import addon-specific modules
@@ -171,7 +173,10 @@ class Feature {
     };
 
     // run once now on the most recent window.
-    const win = Services.wm.getMostRecentWindow("navigator:browser");
+    const win = RecentWindow.getMostRecentBrowserWindow({
+      private: false,
+      allowPopups: false,
+    });
 
     /*
     * Note: Why we are using <browser> as the key in each WeakMap in this.state:
@@ -594,7 +599,10 @@ class Feature {
       return;
     }
 
-    const currentWin = Services.wm.getMostRecentWindow("navigator:browser");
+    const currentWin = RecentWindow.getMostRecentBrowserWindow({
+      private: false,
+      allowPopups: false,
+    });
 
     // If user changes tabs but stays within current window we want to update
     // the status of the pageAction, then reshow it if the new page has had any
@@ -730,7 +738,10 @@ class Feature {
       { defineAs: "sendMessageToChrome"}
     );
     // Get the quantities for the pageAction panel for the current page
-    const win = Services.wm.getMostRecentWindow("navigator:browser");
+    const win = RecentWindow.getMostRecentBrowserWindow({
+      private: false,
+      allowPopups: false,
+    });
     if (win.gBrowser.selectedBrowser) {
       const browser = win.gBrowser.selectedBrowser;
       this.updateQuantities(browser);


### PR DESCRIPTION
…s #139.

The Problem: If I have both a private and non-private window open, but the non-private window is currently active/on top, `Services.wm.getMostRecentWindow("navigator:browser")` would tell me the most recent window is a private window.
Per MattN this might be a feature as we want to err on being more Private than less in the case a Private Window is open. He recommends using `RecentWindow.jsm` instead, which has more options for determining which window is "most recent".

Also sneaking in another fix for a minor issue where the pageAction panel wasn't dismissing on window deactivate.