### PR TITLE
End study if user turns on private browsing autostart. Follow up for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All study endings _except_ `"ineligible"` have a survey at the end of the study.
 * reason = `"user-disable"`: User has uninstalled the addon from `about:addons`
 * reason = `"expired"`: Study has expired.
 * reason = `"ineligible"`: User is ineligible for the study as determined by the `Config.study.isEligible()`. See [Eligibility](https://github.com/biancadanforth/tracking-protection-shield-study#eligibility) in the README.
+* reason = `"user-enabled-auto-private-browsing"`: Some time after install, the user has set a History preference to "Always use Private Browsing mode". This means every window is a private window.
 
 **Study-specific endings**
 * reason= `"user-disabled-builtin-tracking-protection"`: User has lowered the level of Tracking Protection compared to their treatment branch from `about:preferences` or `about:config`.

--- a/addon/lib/Config.jsm
+++ b/addon/lib/Config.jsm
@@ -59,6 +59,9 @@ const config = {
       "expired": {
         "baseUrl": `${SURVEY_URL}?reason=expired`,
       },
+      "user-enabled-auto-private-browsing": {
+        "baseUrl": `${SURVEY_URL}?reason=user-enabled-auto-private-browsing`,
+      },
       /** User defined endings */
       "user-disabled-builtin-tracking-protection": {
         "baseUrl": `${SURVEY_URL}?reason=user-disabled-builtin-tracking-protection`,

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -340,7 +340,7 @@ class Feature {
             event: "study-ended",
             reason,
           });
-          await this.endStudy(reason, false);
+          await this.endStudy({ reason }, false);
         }
         break;
     }
@@ -804,7 +804,7 @@ class Feature {
           ui_event: message,
         });
 
-        Storage.update("behavior-summary", {intro_reject: "true"}).then(() => this.endStudy(message));
+        Storage.update("behavior-summary", {intro_reject: "true"}).then(() => this.endStudy({ reason: message }));
         break;
       case "page-action-reject":
         this.log.debug("You clicked 'Disable Protection' on the pageAction panel.");
@@ -831,7 +831,7 @@ class Feature {
           ui_event: message,
         });
 
-        Storage.update("behavior-summary", {reject: "true"}).then(() => this.endStudy(message));
+        Storage.update("behavior-summary", {reject: "true"}).then(() => this.endStudy({ reason: message }));
         break;
       case "browser-resize":
         this.resizeBrowser(JSON.parse(data));
@@ -1297,12 +1297,13 @@ class Feature {
     }
   }
 
+  // reason is an object with a "reason" key
   async endStudy(reason, shouldResetTP = true) {
     this.isStudyEnding = true;
     if (shouldResetTP) {
       this.resetBuiltInTrackingProtection();
     }
-    await this.studyUtils.endStudy({ reason });
+    await this.studyUtils.endStudy(reason);
   }
 
   async uninit() {


### PR DESCRIPTION
…#147.

In PR #149, I added an eligibility requirement that this private browsing autostart pref is not enabled. However, that does not end the study if the user turns the pref on during the study. This PR handles that case.

I added this pref observer to bootstrap.js rather than Feature.jsm, since it really should be a check all Shield studies make generally, just like study expiry.
I also:
* Updated the Study Endings section in the README
* Added this new ending to Config.jsm so the user gets a survey
* Reformatted the first arg into Feature.endStudy to be an object with a 'reason' key to better match StudyUtils.endStudy, for which it is a wrapper. I verified that each of these calls to endStudy still work as expected.