### PR TITLE
Fix a bunch of style issues between OSes.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -103,6 +103,9 @@ class TrackingProtectionStudy {
 
       const newContainer = doc.createElement("div");
       newContainer.id = `${NEW_TAB_CONTAINER_DIV_ID}`;
+      if (state.OS === "Windows" || state.OS === "Linux") {
+        newContainer.classList.add("windows-or-linux-os");
+      }
       newContainer.append(div);
 
       // There's only one <main> element on the new tab page

--- a/addon/content/scripts/intro-panel.js
+++ b/addon/content/scripts/intro-panel.js
@@ -12,7 +12,8 @@ function onChromeListening(copy) {
 
 class IntroPanel {
   constructor(copy) {
-    this.copy = copy;
+    this.copy = JSON.parse(copy);
+    this.OS = this.copy.OS;
 
     if (document.readyState === "complete") {
       this.handleLoad();
@@ -28,6 +29,9 @@ class IntroPanel {
     this.introPanelMessage = document.getElementById("tracking-protection-study-intro-message");
     this.primaryButton = document.getElementById("tracking-protection-study-primary-button");
     this.secondaryButton = document.getElementById("tracking-protection-study-secondary-button");
+    if (this.OS === "Linux") {
+      this.secondaryButton.classList.add("linux-os");
+    }
     this.confirmationPanel = document.getElementById("tracking-protection-study-confirmation-panel-box");
     this.confirmationCancelButton = document.getElementById("tracking-protection-study-confirmation-default-button");
     this.confirmationDisableButton = document.getElementById("tracking-protection-study-confirmation-secondary-button");
@@ -52,9 +56,8 @@ class IntroPanel {
   }
 
   addCustomContent() {
-    const copyParsed = JSON.parse(this.copy);
-    this.introPanelHeading.textContent = copyParsed.introHeader;
-    this.introPanelMessage.textContent = copyParsed.introMessage;
+    this.introPanelHeading.textContent = this.copy.introHeader;
+    this.introPanelMessage.textContent = this.copy.introMessage;
   }
 
   addClickListeners() {

--- a/addon/content/styles/intro-panel.css
+++ b/addon/content/styles/intro-panel.css
@@ -103,6 +103,10 @@ body {
   cursor: pointer;
 }
 
+#tracking-protection-study-secondary-button.linux-os {
+  font-size: 12px;
+}
+
 #tracking-protection-study-secondary-button:hover {
   text-decoration: underline;
 }

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -100,6 +100,7 @@ class Feature {
     this.TP_ENABLED_IN_PRIVATE_WINDOWS = (this.treatment === "control");
     this.PREF_TP_ENABLED_GLOBALLY = "privacy.trackingprotection.enabled";
     this.PREF_TP_ENABLED_IN_PRIVATE_WINDOWS = "privacy.trackingprotection.pbmode.enabled";
+    this.PAGE_ACTION_BUTTON_WRAPPER_ID = "tracking-protection-study-button-wrapper";
     this.PAGE_ACTION_BUTTON_ID = "tracking-protection-study-button";
     this.PANEL_ID = "tracking-protection-study-intro-panel";
 
@@ -444,7 +445,7 @@ class Feature {
     const pageActionButton = win.document.getElementById(`${this.PAGE_ACTION_BUTTON_ID}`);
     if (pageActionButton) {
       pageActionButton.removeEventListener("command", this.handlePageActionButtonCommandRef);
-      pageActionButton.parentElement.removeChild(pageActionButton);
+      pageActionButton.parentElement.remove();
     }
   }
 
@@ -1209,16 +1210,18 @@ class Feature {
     let pageActionButton = doc.getElementById(`${this.PAGE_ACTION_BUTTON_ID}`);
 
     if (!pageActionButton) {
+      const pageActionWrapper = doc.createElementNS(this.XUL_NS, "hbox");
+      pageActionWrapper.setAttribute("id", `${this.PAGE_ACTION_BUTTON_WRAPPER_ID}`);
       pageActionButton = doc.createElementNS(this.XUL_NS, "toolbarbutton");
-      pageActionButton.style.backgroundColor = "green";
       pageActionButton.setAttribute("id", `${this.PAGE_ACTION_BUTTON_ID}`);
       pageActionButton.setAttribute(
         "image",
         `resource://${STUDY}/content/tp-shield.svg`);
       pageActionButton.addEventListener("command", this.handlePageActionButtonCommandRef);
       // listener gets removed when hidePageAction is called or on uninit
+      pageActionWrapper.append(pageActionButton);
 
-      urlbar.append(pageActionButton);
+      urlbar.append(pageActionWrapper);
     }
   }
 

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -759,6 +759,7 @@ class Feature {
         pageActionMessage: this.pageActionPanelMessages[this.treatment],
         firstQuantity,
         secondQuantity,
+        OS: this.OS,
       }));
   }
 

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -103,6 +103,11 @@ class Feature {
     this.PAGE_ACTION_BUTTON_WRAPPER_ID = "tracking-protection-study-button-wrapper";
     this.PAGE_ACTION_BUTTON_ID = "tracking-protection-study-button";
     this.PANEL_ID = "tracking-protection-study-intro-panel";
+    // Some CSS styles need to change based on operating system, "WINNT" is Windows,
+    // "Darwin" is Mac and "Linux" is Linux
+    const appInfoOS = Services.appinfo.OS;
+    this.OS = appInfoOS === "WINNT" ? "Windows" : (appInfoOS === "Darwin") ? "Mac" : "Linux";
+
 
     // Estimating # blocked ads as a percentage of # blocked resources
     this.MAX_AD_FRACTION = 0.065;
@@ -230,6 +235,7 @@ class Feature {
           timeSaved: this.state.totalTimeSaved,
           blockedAds: this.state.totalBlockedAds,
           newTabMessage: this.newTabMessages[this.treatment],
+          OS: this.OS,
         });
         break;
       case "TrackingStudy:NewTabOpenTime":
@@ -1136,6 +1142,7 @@ class Feature {
           timeSaved: this.state.totalTimeSaved,
           blockedAds: this.state.totalBlockedAds,
           newTabMessage: this.newTabMessages[this.treatment],
+          OS: this.OS,
         });
         // If the pageAction panel is showing, and the tab is the topmost/active tab,
         // update the quantities dynamically

--- a/addon/skin/tracking-protection-study.css
+++ b/addon/skin/tracking-protection-study.css
@@ -39,6 +39,11 @@
   line-height: 1.25;
 }
 
+#tracking-protection-messaging-study-container.windows-or-linux-os {
+  margin-top: 20px;
+  padding: 0 25px;
+}
+
 #tracking-protection-messaging-study-message::before {
   content: "";
   display: inline-block;

--- a/addon/skin/tracking-protection-study.css
+++ b/addon/skin/tracking-protection-study.css
@@ -1,9 +1,17 @@
 #tracking-protection-study-button-wrapper {
-  background: green;
+  background-color: green;
   margin-right: 3px;
   cursor: pointer;
   font-size: .8em;
   border-radius: 5px;
+}
+
+#tracking-protection-study-button {
+  /*
+  * Needed for Linux OS otherwise default toolbarbutton -moz-appearance overrides
+  * some styles like hover and padding.
+  */
+  -moz-appearance: none !important;
 }
 
 #tracking-protection-study-button > .toolbarbutton-text {

--- a/addon/skin/tracking-protection-study.css
+++ b/addon/skin/tracking-protection-study.css
@@ -1,4 +1,6 @@
-#tracking-protection-study-button {
+#tracking-protection-study-button-wrapper {
+  background: green;
+  margin-right: 3px;
   cursor: pointer;
   font-size: .8em;
   border-radius: 5px;


### PR DESCRIPTION
For some reason on Windows, the background-color property for the XUL toolbarbutton element was not working. I ended up wrapping the element in an hbox xul element instead.

### Before:
<img width="179" alt="screen shot 2018-03-10 at 12 10 21 pm" src="https://user-images.githubusercontent.com/17437436/37246315-11240b6e-245c-11e8-908a-95a80718c1ee.png">

### After:
<img width="197" alt="screen shot 2018-03-10 at 12 19 31 pm" src="https://user-images.githubusercontent.com/17437436/37246420-772f47a6-245d-11e8-8090-274313aa9413.png">

Also fixed some padding and a weird hover effect issue in Linux described by Carmen [below](https://github.com/biancadanforth/tracking-protection-shield-study/pull/158#issuecomment-371905937):
### Before:
![screen shot 2018-03-10 at 12 13 15 pm](https://user-images.githubusercontent.com/17437436/37246339-76c19388-245c-11e8-9c6b-fa16199d82b9.png)

### After: (there is no hover effect)
<img width="197" alt="screen shot 2018-03-10 at 12 19 31 pm" src="https://user-images.githubusercontent.com/17437436/37246405-55f0fc56-245d-11e8-8dbe-1765dc4cb70f.png">

Also improved whitespace between bottom of search bar and top of new tab modification div element on Windows and Linux:
### Before:
<img width="695" alt="screen shot 2018-03-10 at 12 15 20 pm" src="https://user-images.githubusercontent.com/17437436/37246356-ba0b56ce-245c-11e8-9e4e-edc72e4e5188.png">

### After:
<img width="721" alt="new-tab-page-linux" src="https://user-images.githubusercontent.com/17437436/37246292-9ddd84fa-245b-11e8-99b1-e0a6daf3972c.png">

Also, the font size for the "Disable Protection" button on the intro panel for Linux was strangely large, so I added an OS-specific style to make it more closely match the other button:

### Before:
<img width="350" alt="screen shot 2018-03-10 at 12 55 59 pm" src="https://user-images.githubusercontent.com/17437436/37246657-6bc57c82-2462-11e8-94c2-6c60047c8ebc.png">

### After:
<img width="343" alt="screen shot 2018-03-10 at 12 51 33 pm" src="https://user-images.githubusercontent.com/17437436/37246648-386c64a4-2462-11e8-9114-7ea02d0a7f21.png">
