### PR TITLE
Check for ad blockers on install and during study. Fixes #162.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The purpose of this study is to test various types of messaging around [Tracking
 
 Users are ineligible for the study if:
 * They have set a History preference to "Always use Private Browsing mode". This means every window is a private window.
+* They already have a popular ad blocker installed (e.g. uBlock Origin).
 * They have already changed their Tracking Protection setting from the default.
 
 ## Treatment Branches
@@ -57,6 +58,7 @@ All study endings _except_ `"ineligible"` have a survey at the end of the study.
 * reason = `"user-enabled-builtin-tracking-protection"`: User has raised the level of Tracking Protection compared to their treatment branch from `about:preferences` or `about:config`.
 * reason = `"introduction-confirmation-leave-study"`: User has opted to disable Tracking Protection from the Introduction panel confirmation screen.
 * reason = `"page-action-confirmation-leave-study"`: User has opted to disable Tracking Protection from the page action panel confirmation screen.
+* reason = `"user-installed-ad-blocker"`: User has installed an ad blocker which can prevent Tracking Protection from blocking trackers.
 
 ## Testing Preferences
 The following preferences can be set to customize the study behavior for testing purposes.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -19,6 +19,7 @@ The STUDY SPECIFIC ENDINGS this study supports are:
 - "user-enabled-builtin-tracking-protection"
 - "introduction-confirmation-leave-study"
 - "page-action-confirmation-leave-study"
+- "user-installed-ad-blocker"
 
 
 ## `shield-study-addon` pings, specific to THIS study.
@@ -166,7 +167,6 @@ version       3
     "covariates_dnt_enabled": "false",
     "covariates_history_enabled": "true",
     "covariates_app_update_enabled": "false",
-    "covariates_has_adblocker": "false"
   }
 }
 ```
@@ -324,7 +324,6 @@ version       3
     "covariates_dnt_enabled": "false",
     "covariates_history_enabled": "true",
     "covariates_app_update_enabled": "false",
-    "covariates_has_adblocker": "false"
   }
 }
 ```

--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -38,6 +38,8 @@ See the [User Flow](https://github.com/biancadanforth/tracking-protection-shield
 
 ## Functional Tests to Perform
 
+- If the user has an ad blocker installed (one of: Disconnect, uBlock Origin, AdBlock Plus, AdBlock for Firefox or Ghostery) before the study installs, the study will end with reason = `ineligible`. There is no survey. (#162)
+- If the user installs one of the ad blockers above during the study, the study ends with reason = `user-installed-ad-blocker`. There is a survey. (#162)
 - In the "pseudo-control" treatment for a clean profile, ensure the user does not receive the Tracking Protection onboarding tour (Something like this [page](https://www.mozilla.org/en-US/firefox/59.0/tracking-protection/start/?step=2&newtab=true)) after the study has been installed, #145.
 - When the user proactively changes the state of Tracking Protection (e.g. through `about:preferences` or `about:config`), the study ends, and their updated setting for Tracking Protection is not changed.
 - If the study runs to completion or the user uninstalls the add-on, the study ends, resetting Tracking Protection to its default value (ON in private windows only); #21 .
@@ -297,7 +299,6 @@ version 3
     "covariates_dnt_enabled": "false",
     "covariates_history_enabled": "true",
     "covariates_app_update_enabled": "true",
-    "covariates_has_adblocker": "false"
   }
 }
 

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -243,10 +243,10 @@ this.Bootstrap = {
       // Tells already loaded frame scripts to shutdown
       Services.mm.broadcastAsyncMessage("TrackingStudy:Uninstalling");
 
-      if (this.feature)
+      if (this.feature) {
         await this.feature.reportBehaviorSummary();
-
-      await Storage.clear();
+        await Storage.clear();
+      }
     }
 
     // Tells already loaded frame scripts to shutdown


### PR DESCRIPTION
* Removed covariate of has_adblocker in summary ping in docs and in Feature.jsm.
* Check for popular ad blockers as an eligibility requirement on install.
* Check for popular ad blockers any time an add-on is installed during the study.
* Added end study reason of 'user-installed-ad-blocker' in docs, in Config.jsm for a survey and in Feature.jsm.