### PR TITLE
Correctly pluralize ad(s) and tracker(s) in all UI. Fixes #125.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -162,18 +162,34 @@ class TrackingProtectionStudy {
   }
 
   updateMessage(state) {
-    const parsedTime = this.getHumanReadableTimeVals(
-      parseInt(state.timeSaved, this.RADIX)
-    );
     let message = this.newTabMessage;
+
+    // Update first quantity: blocked resources/trackers
+    const blockedResources = parseInt(state.blockedResources, this.RADIX);
     // toLocaleString adds ',' for large number values; ex: 1000 will become 1,000.
     message = message.replace(
       "${blockedRequests}",
-      parseInt(state.blockedResources, this.RADIX).toLocaleString()
+      blockedResources.toLocaleString()
     );
+    const trackerUnit = blockedResources === 1 ? "tracker" : "trackers";
+    message = message.replace(
+      "${trackerUnit}",
+      trackerUnit,
+    );
+
+    // Update second quantity: blocked ads or time saved
+    const blockedAds = parseInt(state.blockedAds, this.RADIX);
     message = message.replace(
       "${blockedAds}",
-      parseInt(state.blockedAds, this.RADIX).toLocaleString()
+      blockedAds.toLocaleString()
+    );
+    const adUnit = blockedAds === 1 ? "advertisement" : "advertisements";
+    message = message.replace(
+      "${adUnit}",
+      adUnit
+    );
+    const parsedTime = this.getHumanReadableTimeVals(
+      parseInt(state.timeSaved, this.RADIX)
     );
     message = message.replace("${time}", parsedTime);
     return message;

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -169,8 +169,8 @@ class Feature {
     };
 
     this.newTabMessages = {
-      fast: "Firefox blocked <span class='tracking-protection-messaging-study-message-quantity'>${blockedRequests}</span> trackers and saved you ${time}.",
-      private: "Firefox blocked <span class='tracking-protection-messaging-study-message-quantity'>${blockedRequests}</span> trackers and <span class='tracking-protection-messaging-study-message-quantity'>${blockedAds}</span> advertisements.",
+      fast: "Firefox blocked <span class='tracking-protection-messaging-study-message-quantity'>${blockedRequests}</span> ${trackerUnit} and saved you ${time}.",
+      private: "Firefox blocked <span class='tracking-protection-messaging-study-message-quantity'>${blockedRequests}</span> ${trackerUnit} and <span class='tracking-protection-messaging-study-message-quantity'>${blockedAds}</span> ${adUnit}.",
     };
 
     this.introPanelHeaders = {

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -186,7 +186,7 @@ class Feature {
     this.pageActionPanelQuantities = {
       // both branches show one quantity as # blocked resources in addition to one variable quantity
       fast: '<span id="tracking-protection-study-page-action-num-other-quantity" class="tracking-protection-study-page-action-quantity">${timeSaved}</span><span class="tracking-protection-study-page-action-copy">${timeUnit}<br />saved</span>',
-      private: '<span id="tracking-protection-study-page-action-num-other-quantity" class="tracking-protection-study-page-action-quantity">${blockedAds}</span><span class="tracking-protection-study-page-action-copy">ads<br />blocked</span>',
+      private: '<span id="tracking-protection-study-page-action-num-other-quantity" class="tracking-protection-study-page-action-quantity">${blockedAds}</span><span class="tracking-protection-study-page-action-copy">${adUnit}<br />blocked</span>',
     };
 
     this.pageActionPanelMessages = {


### PR DESCRIPTION
#125 Has good before pics. Here are some after pics:

### After (pageAction panel):
"private" branch
![screen shot 2018-03-11 at 3 11 54 pm](https://user-images.githubusercontent.com/17437436/37259441-8d3e7120-2543-11e8-95cd-8febc168c13c.png)
"fast" branch
![screen shot 2018-03-11 at 3 13 33 pm](https://user-images.githubusercontent.com/17437436/37259443-920841fe-2543-11e8-9a21-43ba492a6db5.png)


### After (new tab mod)
"private" branch
![screen shot 2018-03-11 at 4 05 47 pm](https://user-images.githubusercontent.com/17437436/37259670-5d2dd838-2546-11e8-950e-5859b010e4f3.png)
"fast" branch
![screen shot 2018-03-11 at 3 59 52 pm](https://user-images.githubusercontent.com/17437436/37259674-6759b66a-2546-11e8-9d48-96550c006755.png)
