### PR TITLE
Prevent new-tab-closed event from firing twice in a row. Fixes #159.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -38,7 +38,11 @@ class TrackingProtectionStudy {
 
   initTimer() {
     this.openingTime = Math.floor(Date.now() / 1000);
-    this.contentWindow.addEventListener("beforeunload", this.sendOpenTimeRef);
+    this.contentWindow.addEventListener(
+      "beforeunload",
+      this.sendOpenTimeRef,
+      { once: true }
+    );
   }
 
   receiveMessage(msg) {


### PR DESCRIPTION
I'm still not sure why it's firing twice every time...

I can only see the `about:newtab` page load event firing once, as expected, but for some reason the `"beforeunload"` event fires twice every time.

For now, I can pass an `options` argument to the listener to only fire once.