### PR TITLE
Dismiss panel on window sizemodechange. Fixes #173. Fixes #152.

### DIFF
--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -545,7 +545,7 @@ class Feature {
       case STATE_MAXIMIZED:
       case STATE_NORMAL:
       case STATE_FULLSCREEN:
-        this.hidePanel("window-resize", isIntroPanel);
+        this.hidePanel("window-sizemodechange", isIntroPanel);
         break;
     }
   }

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -538,11 +538,12 @@ class Feature {
     const isIntroPanel = this.state.introPanelIsShowing;
 
     const STATE_MAXIMIZED = 1;
+    const STATE_MINIMIZED = 2;
     const STATE_NORMAL = 3;
     const STATE_FULLSCREEN = 4;
     switch (win.windowState) {
-      // The only state we don't care about is minimized
       case STATE_MAXIMIZED:
+      case STATE_MINIMIZED:
       case STATE_NORMAL:
       case STATE_FULLSCREEN:
         this.hidePanel("window-sizemodechange", isIntroPanel);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tracking-protection-messaging-study",
   "description": "Tracking Protection Messaging Shield Study",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Mozilla Bianca Danforth <bdanforth@mozilla.com>",
   "addon": {
     "$ABOUT": "use these variables fill the moustache templates",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tracking-protection-messaging-study",
   "description": "Tracking Protection Messaging Shield Study",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Mozilla Bianca Danforth <bdanforth@mozilla.com>",
   "addon": {
     "$ABOUT": "use these variables fill the moustache templates",


### PR DESCRIPTION
After having all kinds of problems on Windows to display the intro panel correctly on window resize, I decided to change the behavior of the intro panel (and pageAction panel) to be dismissed for all platforms when the window resizes, to ensure consistent, non-buggy behavior. I checked this change with pdol, the stakeholder.