### PR TITLE
Remove padding in about:newtab. Fixes #177.

### DIFF
--- a/addon/content/new-tab-variation.js
+++ b/addon/content/new-tab-variation.js
@@ -116,9 +116,6 @@ class TrackingProtectionStudy {
 
       const newContainer = doc.createElement("div");
       newContainer.id = `${NEW_TAB_CONTAINER_DIV_ID}`;
-      if (state.OS === "Windows" || state.OS === "Linux") {
-        newContainer.classList.add("windows-or-linux-os");
-      }
       const span = doc.createElement("span");
       span.innerHTML = svg;
       newContainer.append(span);

--- a/addon/lib/Feature.jsm
+++ b/addon/lib/Feature.jsm
@@ -275,7 +275,6 @@ class Feature {
           timeSaved: this.state.totalTimeSaved,
           blockedAds: this.state.totalBlockedAds,
           newTabMessage: this.newTabMessages[this.treatment],
-          OS: this.OS,
         });
         break;
       case "TrackingStudy:NewTabOpenTime":
@@ -1208,7 +1207,6 @@ class Feature {
             timeSaved: this.state.totalTimeSaved,
             blockedAds: this.state.totalBlockedAds,
             newTabMessage: this.newTabMessages[this.treatment],
-            OS: this.OS,
           });
           // If the pageAction panel is showing, and the tab is the topmost/active tab,
           // update the quantities dynamically

--- a/addon/skin/tracking-protection-study.css
+++ b/addon/skin/tracking-protection-study.css
@@ -46,10 +46,6 @@
   line-height: 1.25;
 }
 
-#tracking-protection-messaging-study-container.windows-or-linux-os {
-  padding: 0 25px;
-}
-
 #tracking-protection-messaging-study-svg {
   width: 20px;
   height: 20px;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tracking-protection-messaging-study",
   "description": "Tracking Protection Messaging Shield Study",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Mozilla Bianca Danforth <bdanforth@mozilla.com>",
   "addon": {
     "$ABOUT": "use these variables fill the moustache templates",


### PR DESCRIPTION
Also update version...

I realized when I was testing yesterday on Linux and Windows, that I was not testing on 59, but in Nightly. Sure enough, @SoftVision-CarmenFat was right that the padding is off. This removes the padding so it aligns on Windows and Linux.